### PR TITLE
[feat] 우산 추가/수정 기능, 테스트 리팩토링(#37, #38)

### DIFF
--- a/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
+++ b/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
@@ -1,0 +1,7 @@
+package upbrella.be.store.StoreRepository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import upbrella.be.store.entity.StoreMeta;
+
+public interface StoreMetaRepository extends JpaRepository<StoreMeta, Long> {
+}

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -1,6 +1,6 @@
 package upbrella.be.store.entity;
 
-import lombok.Getter;
+import lombok.*;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -8,6 +8,9 @@ import javax.persistence.Id;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class StoreMeta {
 
     @Id

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -1,6 +1,8 @@
 package upbrella.be.store.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -9,8 +11,10 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "UPDATE storeMeta SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class StoreMeta {
 
     @Id

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -1,0 +1,18 @@
+package upbrella.be.store.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import upbrella.be.store.StoreRepository.StoreMetaRepository;
+import upbrella.be.store.entity.StoreMeta;
+
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class StoreMetaService {
+    private final StoreMetaRepository storeMetaRepository;
+
+    public Optional<StoreMeta> findByStoreMetaId(long id) {
+        return storeMetaRepository.findById(id);
+    }
+}

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -5,14 +5,13 @@ import org.springframework.stereotype.Service;
 import upbrella.be.store.StoreRepository.StoreMetaRepository;
 import upbrella.be.store.entity.StoreMeta;
 
-import java.util.Optional;
-
 @Service
 @RequiredArgsConstructor
 public class StoreMetaService {
     private final StoreMetaRepository storeMetaRepository;
 
-    public Optional<StoreMeta> findByStoreMetaId(long id) {
-        return storeMetaRepository.findById(id);
+    public StoreMeta findById(long id) {
+        return storeMetaRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -1,16 +1,15 @@
 package upbrella.be.umbrella.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import upbrella.be.store.entity.StoreMeta;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@NoArgsConstructor
+@Builder
 public class Umbrella {
 
     @Id
@@ -23,8 +22,12 @@ public class Umbrella {
     private boolean rentable;
     private boolean deleted;
 
-    public static Umbrella createOf(StoreMeta storeMeta, long uuid, boolean rentable) {
-
-        return new Umbrella(null, storeMeta, uuid, rentable, false);
+    public static Umbrella ofCreated(StoreMeta storeMeta, long uuid, boolean rentable) {
+        return Umbrella.builder()
+                .storeMeta(storeMeta)
+                .uuid(uuid)
+                .rentable(rentable)
+                .deleted(false)
+                .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -1,21 +1,30 @@
 package upbrella.be.umbrella.entity;
 
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import upbrella.be.store.entity.StoreMeta;
 
 import javax.persistence.*;
 
 @Entity
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor
 public class Umbrella {
 
     @Id
-    @GeneratedValue
-    private long id;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
     @ManyToOne
     @JoinColumn(name = "store_meta_id")
     private StoreMeta storeMeta;
     private long uuid;
     private boolean rentable;
     private boolean deleted;
+
+    public static Umbrella createOf(StoreMeta storeMeta, long uuid, boolean rentable) {
+
+        return new Umbrella(null, storeMeta, uuid, rentable, false);
+    }
 }

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -1,6 +1,8 @@
 package upbrella.be.umbrella.entity;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 import upbrella.be.store.entity.StoreMeta;
 
 import javax.persistence.*;
@@ -8,13 +10,15 @@ import javax.persistence.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
+@SQLDelete(sql = "UPDATE umbrella SET deleted = true WHERE id = ?")
+@Where(clause = "deleted = false")
 public class Umbrella {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private long id;
     @ManyToOne
     @JoinColumn(name = "store_meta_id")
     private StoreMeta storeMeta;
@@ -24,6 +28,16 @@ public class Umbrella {
 
     public static Umbrella ofCreated(StoreMeta storeMeta, long uuid, boolean rentable) {
         return Umbrella.builder()
+                .storeMeta(storeMeta)
+                .uuid(uuid)
+                .rentable(rentable)
+                .deleted(false)
+                .build();
+    }
+
+    public static Umbrella ofUpdated(long id, StoreMeta storeMeta, long uuid, boolean rentable) {
+        return Umbrella.builder()
+                .id(id)
                 .storeMeta(storeMeta)
                 .uuid(uuid)
                 .rentable(rentable)

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -1,0 +1,9 @@
+package upbrella.be.umbrella.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+import upbrella.be.umbrella.entity.Umbrella;
+
+public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
+    boolean existsByUuid(@Param("uuid") long uuid);
+}

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -1,9 +1,8 @@
 package upbrella.be.umbrella.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.repository.query.Param;
 import upbrella.be.umbrella.entity.Umbrella;
 
 public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
-    boolean existsByUuid(@Param("uuid") long uuid);
+    boolean existsByUuid(long uuid);
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -23,7 +23,7 @@ public class UmbrellaService {
         return null;
     }
 
-    public void addUmbrella(UmbrellaRequest umbrellaRequest) {
+    public Umbrella addUmbrella(UmbrellaRequest umbrellaRequest) {
 
         StoreMeta storeMeta = storeMetaRepository.findById(umbrellaRequest.getStoreMetaId())
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
@@ -32,13 +32,13 @@ public class UmbrellaService {
             throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
         }
 
-        Umbrella umbrella = Umbrella.createOf(
-                storeMeta,
-                umbrellaRequest.getUuid(),
-                umbrellaRequest.isRentable()
+        return umbrellaRepository.save(
+                Umbrella.ofCreated(
+                        storeMeta,
+                        umbrellaRequest.getUuid(),
+                        umbrellaRequest.isRentable()
+                )
         );
-
-        umbrellaRepository.save(umbrella);
     }
     public void modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
 

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -1,13 +1,21 @@
 package upbrella.be.umbrella.service;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import upbrella.be.store.StoreRepository.StoreMetaRepository;
+import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
+import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.umbrella.repository.UmbrellaRepository;
 
 import java.util.List;
 
 @Service
+@RequiredArgsConstructor
 public class UmbrellaService {
+    private final UmbrellaRepository umbrellaRepository;
+    private final StoreMetaRepository storeMetaRepository;
     public List<UmbrellaResponse> findAllUmbrellas() {
         return null;
     }
@@ -15,8 +23,26 @@ public class UmbrellaService {
         return null;
     }
 
-    public void addUmbrella(UmbrellaRequest umbrellaRequest) {}
-    public void modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {}
+    public void addUmbrella(UmbrellaRequest umbrellaRequest) {
+
+        StoreMeta storeMeta = storeMetaRepository.findById(umbrellaRequest.getStoreMetaId())
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
+
+        if (umbrellaRepository.existsByUuid(umbrellaRequest.getUuid())) {
+            throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
+        }
+
+        Umbrella umbrella = Umbrella.createOf(
+                storeMeta,
+                umbrellaRequest.getUuid(),
+                umbrellaRequest.isRentable()
+        );
+
+        umbrellaRepository.save(umbrella);
+    }
+    public void modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
+
+    }
     public void deleteUmbrella(long id) {}
 
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -2,31 +2,34 @@ package upbrella.be.umbrella.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import upbrella.be.store.StoreRepository.StoreMetaRepository;
 import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.repository.UmbrellaRepository;
 
+import javax.transaction.Transactional;
 import java.util.List;
 
 @Service
 @RequiredArgsConstructor
 public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
-    private final StoreMetaRepository storeMetaRepository;
+    private final StoreMetaService storeMetaService;
+
     public List<UmbrellaResponse> findAllUmbrellas() {
         return null;
     }
+
     public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId) {
         return null;
     }
 
+    @Transactional
     public Umbrella addUmbrella(UmbrellaRequest umbrellaRequest) {
 
-        StoreMeta storeMeta = storeMetaRepository.findById(umbrellaRequest.getStoreMetaId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
+        StoreMeta storeMeta = storeMetaService.findById(umbrellaRequest.getStoreMetaId());
 
         if (umbrellaRepository.existsByUuid(umbrellaRequest.getUuid())) {
             throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
@@ -40,9 +43,29 @@ public class UmbrellaService {
                 )
         );
     }
-    public void modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
 
+    @Transactional
+    public Umbrella modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
+
+        StoreMeta storeMeta = storeMetaService.findById(umbrellaRequest.getStoreMetaId());
+        if (!umbrellaRepository.existsById(id)) {
+            throw new IllegalArgumentException("[ERROR] 존재하지 않는 우산 고유번호입니다.");
+        }
+        if (umbrellaRepository.existsByUuid(umbrellaRequest.getUuid())) {
+            throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
+        }
+
+        return umbrellaRepository.save(
+                Umbrella.ofUpdated(
+                        id,
+                        storeMeta,
+                        umbrellaRequest.getUuid(),
+                        umbrellaRequest.isRentable()
+                )
+        );
     }
-    public void deleteUmbrella(long id) {}
+
+    public void deleteUmbrella(long id) {
+    }
 
 }

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -2,9 +2,7 @@ package upbrella.be.umbrella.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.BDDMockito;
 import org.springframework.http.MediaType;
-import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import upbrella.be.docs.utils.RestDocsSupport;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
@@ -13,9 +11,11 @@ import upbrella.be.umbrella.service.UmbrellaService;
 
 import java.util.List;
 
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
@@ -45,7 +45,7 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                         .rentable(true)
                         .build());
 
-        BDDMockito.given(umbrellaService.findAllUmbrellas())
+        given(umbrellaService.findAllUmbrellas())
                         .willReturn(umbrellaResponseList);
         // when
 
@@ -85,13 +85,13 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                 .rentable(true)
                 .build());
 
-        BDDMockito.given(umbrellaService.findUmbrellasByStoreId(2))
+        given(umbrellaService.findUmbrellasByStoreId(2))
                 .willReturn(umbrellaResponseList);
 
         // when
 
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.get("/umbrellas/{storeId}", 2)
+                        get("/umbrellas/{storeId}", 2)
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("show-umbrellas-by-store-id-doc",
@@ -127,6 +127,7 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                 .rentable(true)
                 .build();
 
+        doNothing().when(umbrellaService).addUmbrella(umbrellaRequest);
         // when
         mockMvc.perform(
                         post("/umbrellas")
@@ -161,7 +162,7 @@ public class UmbrellaControllerTest extends RestDocsSupport {
 
         // when
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.patch("/umbrellas/{umbrellaId}", 1L)
+                        patch("/umbrellas/{umbrellaId}", 1L)
                                 .content(objectMapper.writeValueAsString(umbrellaRequest))
                                 .contentType(MediaType.APPLICATION_JSON)
                                 .accept(MediaType.APPLICATION_JSON)
@@ -189,7 +190,7 @@ public class UmbrellaControllerTest extends RestDocsSupport {
 
         // when
         mockMvc.perform(
-                        RestDocumentationRequestBuilders.delete("/umbrellas/{umbrellaId}", 1)
+                        delete("/umbrellas/{umbrellaId}", 1)
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("delete-umbrella-doc",

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -1,0 +1,159 @@
+package upbrella.be.umbrella.service;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import upbrella.be.store.StoreRepository.StoreMetaRepository;
+import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.umbrella.repository.UmbrellaRepository;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+class UmbrellaServiceTest {
+    private final UmbrellaRepository umbrellaRepository = mock(UmbrellaRepository.class);
+    private final StoreMetaRepository storeMetaRepository = mock(StoreMetaRepository.class);
+    private final UmbrellaService umbrellaService = new UmbrellaService(umbrellaRepository, storeMetaRepository);
+
+    @Test
+    void findAllUmbrellas() {
+    }
+
+    @Test
+    void findUmbrellasByStoreId() {
+    }
+
+    @Nested
+    @DisplayName("우산 추가 API를 호출하면")
+    class addUmbrella {
+
+        @Test
+        @DisplayName("우산을 정상적으로 추가한다.")
+        void success() {
+            // given
+            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
+                    .uuid(43L)
+                    .storeMetaId(2L)
+                    .rentable(true)
+                    .build();
+
+            StoreMeta foundStoreMeta = StoreMeta.builder()
+                    .id(2L)
+                    .name("name")
+                    .thumbnail("thumb")
+                    .deleted(true)
+                    .build();
+
+            Umbrella umbrella = Umbrella.builder()
+                    .id(null)
+                    .uuid(43L)
+                    .deleted(false)
+                    .storeMeta(foundStoreMeta)
+                    .rentable(true)
+                    .build();
+
+            // when
+            given(storeMetaRepository.findById(2L))
+                    .willReturn(Optional.of(foundStoreMeta));
+            given(umbrellaRepository.existsByUuid(43))
+                    .willReturn(false);
+            given(umbrellaRepository.save(any(Umbrella.class)))
+                    .willReturn(umbrella);
+
+            Umbrella addedUmbrella = umbrellaService.addUmbrella(umbrellaRequest);
+
+            // then
+            SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(addedUmbrella.getUuid())
+                    .isEqualTo(43);
+            softly.assertThat(addedUmbrella.getStoreMeta().getId())
+                    .isEqualTo(2L);
+            softly.assertThat(addedUmbrella.getStoreMeta().getName())
+                    .isEqualTo("name");
+            softly.assertThat(addedUmbrella.getStoreMeta().getThumbnail())
+                    .isEqualTo("thumb");
+            softly.assertThat(addedUmbrella.getStoreMeta().isDeleted())
+                    .isEqualTo(true);
+            softly.assertThat(addedUmbrella.isRentable())
+                    .isEqualTo(true);
+            softly.assertThat(addedUmbrella.isDeleted())
+                    .isEqualTo(false);
+            softly.assertAll();
+
+            verify(umbrellaRepository, times(1))
+                    .existsByUuid(43);
+            verify(storeMetaRepository, times(1))
+                    .findById(2L);
+            verify(umbrellaRepository, times(1))
+                    .save(any(Umbrella.class));
+        }
+
+        @Test
+        @DisplayName("우산 고유번호가 이미 존재하는 경우 예외를 발생시킨다.")
+        void withSameId() {
+            // given
+            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
+                    .uuid(43)
+                    .storeMetaId(2)
+                    .rentable(true)
+                    .build();
+
+            StoreMeta foundStoreMeta = StoreMeta.builder()
+                    .id(2L)
+                    .name("name")
+                    .thumbnail("thume")
+                    .deleted(true)
+                    .build();
+
+            given(storeMetaRepository.findById(2L))
+                    .willReturn(Optional.of(foundStoreMeta));
+            given(umbrellaRepository.existsByUuid(43))
+                    .willReturn(true);
+            // when
+
+            assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+            verify(storeMetaRepository, times(1))
+                    .findById(2L);
+            verify(umbrellaRepository, times(1))
+                    .existsByUuid(43);
+            verify(umbrellaRepository, never())
+                    .save(any(Umbrella.class));
+        }
+
+        @Test
+        @DisplayName("추가하려고 하는 가게 고유번호가 존재하지 않는 경우 예외를 발생시킨다.")
+        void atNonExistingStore() {
+            // given
+            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
+                    .uuid(43)
+                    .storeMetaId(2)
+                    .rentable(true)
+                    .build();
+
+            given(storeMetaRepository.findById(2L))
+                    .willReturn(Optional.ofNullable(null));
+            // when
+            assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+            verify(storeMetaRepository, times(1))
+                    .findById(2L);
+            verifyNoInteractions(umbrellaRepository);
+        }
+    }
+
+    @Test
+    void modifyUmbrella() {
+    }
+
+    @Test
+    void deleteUmbrella() {
+    }
+}

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -1,26 +1,26 @@
 package upbrella.be.umbrella.service;
 
 import org.assertj.core.api.SoftAssertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import upbrella.be.store.StoreRepository.StoreMetaRepository;
 import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.repository.UmbrellaRepository;
 
-import java.util.Optional;
-
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
 
 class UmbrellaServiceTest {
     private final UmbrellaRepository umbrellaRepository = mock(UmbrellaRepository.class);
-    private final StoreMetaRepository storeMetaRepository = mock(StoreMetaRepository.class);
-    private final UmbrellaService umbrellaService = new UmbrellaService(umbrellaRepository, storeMetaRepository);
+    private final StoreMetaService storeMetaService = mock(StoreMetaService.class);
+    private final UmbrellaService umbrellaService = new UmbrellaService(umbrellaRepository, storeMetaService);
 
     @Test
     void findAllUmbrellas() {
@@ -31,42 +31,47 @@ class UmbrellaServiceTest {
     }
 
     @Nested
-    @DisplayName("우산 추가 API를 호출하면")
-    class addUmbrella {
-
-        @Test
-        @DisplayName("우산을 정상적으로 추가한다.")
-        void success() {
-            // given
-            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
+    @DisplayName("우산의 고유번호, 협력 지점 고유번호, 대여 여부를 입력받아")
+    class addUmbrellaTest {
+        private UmbrellaRequest umbrellaRequest;
+        private StoreMeta foundStoreMeta;
+        private Umbrella umbrella;
+        @BeforeEach
+        void setUp() {
+            umbrellaRequest = UmbrellaRequest.builder()
                     .uuid(43L)
                     .storeMetaId(2L)
                     .rentable(true)
                     .build();
 
-            StoreMeta foundStoreMeta = StoreMeta.builder()
+            foundStoreMeta = StoreMeta.builder()
                     .id(2L)
                     .name("name")
                     .thumbnail("thumb")
-                    .deleted(true)
+                    .deleted(false)
                     .build();
 
-            Umbrella umbrella = Umbrella.builder()
-                    .id(null)
+            umbrella = Umbrella.builder()
                     .uuid(43L)
                     .deleted(false)
                     .storeMeta(foundStoreMeta)
                     .rentable(true)
                     .build();
+        }
 
-            // when
-            given(storeMetaRepository.findById(2L))
-                    .willReturn(Optional.of(foundStoreMeta));
+        @Test
+        @DisplayName("우산을 정상적으로 추가할 수 있다.")
+        void success() {
+
+            // given
+            given(storeMetaService.findById(2L))
+                    .willReturn(foundStoreMeta);
             given(umbrellaRepository.existsByUuid(43))
                     .willReturn(false);
             given(umbrellaRepository.save(any(Umbrella.class)))
                     .willReturn(umbrella);
 
+            // when
             Umbrella addedUmbrella = umbrellaService.addUmbrella(umbrellaRequest);
 
             // then
@@ -80,77 +85,218 @@ class UmbrellaServiceTest {
             softly.assertThat(addedUmbrella.getStoreMeta().getThumbnail())
                     .isEqualTo("thumb");
             softly.assertThat(addedUmbrella.getStoreMeta().isDeleted())
-                    .isEqualTo(true);
+                    .isEqualTo(false);
             softly.assertThat(addedUmbrella.isRentable())
                     .isEqualTo(true);
             softly.assertThat(addedUmbrella.isDeleted())
                     .isEqualTo(false);
             softly.assertAll();
 
-            verify(umbrellaRepository, times(1))
+            then(umbrellaRepository).should(times(1))
                     .existsByUuid(43);
-            verify(storeMetaRepository, times(1))
+            then(storeMetaService).should(times(1))
                     .findById(2L);
-            verify(umbrellaRepository, times(1))
+            then(umbrellaRepository).should(times(1))
                     .save(any(Umbrella.class));
         }
 
         @Test
         @DisplayName("우산 고유번호가 이미 존재하는 경우 예외를 발생시킨다.")
         void withSameId() {
+
             // given
-            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
-                    .uuid(43)
-                    .storeMetaId(2)
-                    .rentable(true)
-                    .build();
-
-            StoreMeta foundStoreMeta = StoreMeta.builder()
-                    .id(2L)
-                    .name("name")
-                    .thumbnail("thume")
-                    .deleted(true)
-                    .build();
-
-            given(storeMetaRepository.findById(2L))
-                    .willReturn(Optional.of(foundStoreMeta));
+            given(storeMetaService.findById(2L))
+                    .willReturn(foundStoreMeta);
             given(umbrellaRepository.existsByUuid(43))
                     .willReturn(true);
             // when
-
             assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
                     .isInstanceOf(IllegalArgumentException.class);
-            verify(storeMetaRepository, times(1))
+
+            // then
+            then(storeMetaService).should(times(1))
                     .findById(2L);
-            verify(umbrellaRepository, times(1))
+            then(umbrellaRepository).should(times(1))
                     .existsByUuid(43);
-            verify(umbrellaRepository, never())
+            then(umbrellaRepository).should(never())
                     .save(any(Umbrella.class));
         }
 
         @Test
         @DisplayName("추가하려고 하는 가게 고유번호가 존재하지 않는 경우 예외를 발생시킨다.")
         void atNonExistingStore() {
-            // given
-            UmbrellaRequest umbrellaRequest = UmbrellaRequest.builder()
-                    .uuid(43)
-                    .storeMetaId(2)
-                    .rentable(true)
-                    .build();
 
-            given(storeMetaRepository.findById(2L))
-                    .willReturn(Optional.ofNullable(null));
+            // given
+            given(storeMetaService.findById(2L))
+                    .willThrow(new IllegalArgumentException());
+
             // when
             assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
                     .isInstanceOf(IllegalArgumentException.class);
-            verify(storeMetaRepository, times(1))
+            //then
+            then(storeMetaService).should(times(1))
                     .findById(2L);
-            verifyNoInteractions(umbrellaRepository);
+            then(umbrellaRepository).shouldHaveNoInteractions();
         }
     }
 
-    @Test
-    void modifyUmbrella() {
+    @Nested
+    @DisplayName("우산의 고유번호, 협력 지점 고유번호, 대여 여부를 입력받아")
+    class modifyUmbrellaTest {
+        private UmbrellaRequest umbrellaRequest;
+        private StoreMeta foundStoreMeta;
+        private Umbrella umbrella;
+        @BeforeEach
+        void setUp() {
+
+            umbrellaRequest = UmbrellaRequest.builder()
+                    .uuid(50L)
+                    .storeMetaId(5L)
+                    .rentable(true)
+                    .build();
+
+            foundStoreMeta = StoreMeta.builder()
+                    .id(5L)
+                    .name("연세대학교 파스쿠치")
+                    .thumbnail("정면사진.jpg")
+                    .deleted(false)
+                    .build();
+
+            umbrella = Umbrella.builder()
+                    .id(1L)
+                    .uuid(50L)
+                    .deleted(false)
+                    .storeMeta(foundStoreMeta)
+                    .rentable(true)
+                    .build();
+        }
+
+        @Test
+        @DisplayName("우산을 정상적으로 수정한다.")
+        void success() {
+
+            // given
+            given(storeMetaService.findById(5L))
+                    .willReturn(foundStoreMeta);
+            given(umbrellaRepository.existsById(1L))
+                    .willReturn(true);
+            given(umbrellaRepository.existsByUuid(50L))
+                    .willReturn(false);
+            given(umbrellaRepository.save(any(Umbrella.class)))
+                    .willReturn(umbrella);
+
+            // when
+            Umbrella modifiedUmbrella = umbrellaService.modifyUmbrella(1L, umbrellaRequest);
+
+            // then
+            SoftAssertions softly = new SoftAssertions();
+            softly.assertThat(modifiedUmbrella.getUuid())
+                    .isEqualTo(50L);
+            softly.assertThat(modifiedUmbrella.getStoreMeta().getId())
+                    .isEqualTo(5L);
+            softly.assertThat(modifiedUmbrella.getStoreMeta().getName())
+                    .isEqualTo("연세대학교 파스쿠치");
+            softly.assertThat(modifiedUmbrella.getStoreMeta().getThumbnail())
+                    .isEqualTo("정면사진.jpg");
+            softly.assertThat(modifiedUmbrella.getStoreMeta().isDeleted())
+                    .isEqualTo(false);
+            softly.assertThat(modifiedUmbrella.isRentable())
+                    .isEqualTo(true);
+            softly.assertThat(modifiedUmbrella.isDeleted())
+                    .isEqualTo(false);
+            softly.assertAll();
+
+            then(umbrellaRepository).should(times(1))
+                    .existsByUuid(50L);
+            then(umbrellaRepository).should(times(1))
+                    .existsById(1L);
+            then(storeMetaService).should(times(1))
+                    .findById(5L);
+            then(umbrellaRepository).should(times(1))
+                    .save(any(Umbrella.class));
+        }
+
+        @Test
+        @DisplayName("수정하려는 우산 고유번호가 존재하지 않는 경우 예외를 발생시킨다.")
+        void withNonExistingId() {
+
+            // given
+            given(storeMetaService.findById(5L))
+                    .willReturn(foundStoreMeta);
+            given(umbrellaRepository.existsById(1L))
+                    .willReturn(false);
+            given(umbrellaRepository.existsByUuid(50L))
+                    .willReturn(false);
+            given(umbrellaRepository.save(any(Umbrella.class)))
+                    .willReturn(umbrella);
+
+            // when
+            assertThatThrownBy(() -> umbrellaService.modifyUmbrella(1L, umbrellaRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            // then
+            then(umbrellaRepository).should(never())
+                    .existsByUuid(50L);
+            then(umbrellaRepository).should(times(1))
+                    .existsById(1L);
+            then(storeMetaService).should(times(1))
+                    .findById(5L);
+            then(umbrellaRepository).should(never())
+                    .save(any(Umbrella.class));
+        }
+
+        @Test
+        @DisplayName("수정하려는 우산 관리번호가 이미 존재하는 경우 예외를 발생시킨다.")
+        void withAlreadyExistingUuid() {
+
+            // given
+            given(storeMetaService.findById(5L))
+                    .willReturn(foundStoreMeta);
+            given(umbrellaRepository.existsById(1L))
+                    .willReturn(true);
+            given(umbrellaRepository.existsByUuid(50L))
+                    .willReturn(true);
+            given(umbrellaRepository.save(any(Umbrella.class)))
+                    .willReturn(umbrella);
+
+            // when
+            assertThatThrownBy(() -> umbrellaService.modifyUmbrella(1L, umbrellaRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            // then
+            then(umbrellaRepository).should(times(1))
+                    .existsByUuid(50L);
+            then(umbrellaRepository).should(times(1))
+                    .existsById(1L);
+            then(storeMetaService).should(times(1))
+                    .findById(5L);
+            then(umbrellaRepository).should(never())
+                    .save(any(Umbrella.class));
+        }
+
+        @Test
+        @DisplayName("추가하려고 하는 가게 고유번호가 존재하지 않는 경우 예외를 발생시킨다.")
+        void atNonExistingStore() {
+
+            // given
+            given(storeMetaService.findById(5L))
+                    .willThrow(new IllegalArgumentException());
+            given(umbrellaRepository.existsById(1L))
+                    .willReturn(true);
+            given(umbrellaRepository.existsByUuid(50L))
+                    .willReturn(false);
+            given(umbrellaRepository.save(any(Umbrella.class)))
+                    .willReturn(umbrella);
+
+            // when
+            assertThatThrownBy(() -> umbrellaService.modifyUmbrella(1L, umbrellaRequest))
+                    .isInstanceOf(IllegalArgumentException.class);
+
+            // then
+            then(storeMetaService).should(times(1))
+                    .findById(5L);
+            then(umbrellaRepository).shouldHaveNoInteractions();
+        }
     }
 
     @Test


### PR DESCRIPTION
## 🟢 구현내용

- #37
- #38 

## 🧩 고민과 해결과정
- 우산 추가/수정 및 서비스 단위 테스트 구현하였습니다.
- BDD에 따라서 엄밀하게 구분하고, 겹치는 test setup 코드 리팩터링해서 가독성을 조금 개선했습니다.
- 우산 uuid, id DB의 제약조건 모두 예외처리했습니다.
- 처음 2개의 커밋은 이전 PR에 포함되는 내용이라, 마지막 커밋의 내용만 리뷰해주시면 됩니다.