### PR TITLE
[feat] 우산 삭제 기능 및 테스트 코드 작성(#39)

### DIFF
--- a/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
+++ b/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
@@ -3,5 +3,8 @@ package upbrella.be.store.StoreRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.store.entity.StoreMeta;
 
+import java.util.Optional;
+
 public interface StoreMetaRepository extends JpaRepository<StoreMeta, Long> {
+    Optional<StoreMeta> findByIdAndDeletedIsFalse(long id);
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -11,7 +11,7 @@ public class StoreMetaService {
     private final StoreMetaRepository storeMetaRepository;
 
     public StoreMeta findById(long id) {
-        return storeMetaRepository.findById(id)
+        return storeMetaRepository.findByIdAndDeletedIsFalse(id)
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -22,9 +22,8 @@ public class Umbrella {
     private boolean rentable;
     private boolean deleted;
 
-    public static Umbrella delete(Umbrella umbrella) {
-        umbrella.deleted = true;
-        return umbrella;
+    public void delete() {
+        this.deleted = true;
     }
 
     public static Umbrella ofCreated(StoreMeta storeMeta, long uuid, boolean rentable) {

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -1,8 +1,6 @@
 package upbrella.be.umbrella.entity;
 
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 import upbrella.be.store.entity.StoreMeta;
 
 import javax.persistence.*;
@@ -12,8 +10,6 @@ import javax.persistence.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-@SQLDelete(sql = "UPDATE umbrella SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class Umbrella {
 
     @Id

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -22,6 +22,11 @@ public class Umbrella {
     private boolean rentable;
     private boolean deleted;
 
+    public static Umbrella delete(Umbrella umbrella) {
+        umbrella.deleted = true;
+        return umbrella;
+    }
+
     public static Umbrella ofCreated(StoreMeta storeMeta, long uuid, boolean rentable) {
         return Umbrella.builder()
                 .storeMeta(storeMeta)

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -3,6 +3,11 @@ package upbrella.be.umbrella.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.umbrella.entity.Umbrella;
 
+import java.util.Optional;
+
 public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
-    boolean existsByUuid(long uuid);
+
+    Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
+    boolean existsByIdAndDeletedIsFalse(long id);
+    boolean existsByUuidAndDeletedIsFalse(long uuid);
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -71,7 +71,7 @@ public class UmbrellaService {
         // 이미 삭제된 경우도 포함
         Umbrella foundUmbrella = umbrellaRepository.findByIdAndDeletedIsFalse(id)
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 우산 고유번호입니다."));
-        Umbrella.delete(foundUmbrella);
+        foundUmbrella.delete();
     }
 
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -31,7 +31,7 @@ public class UmbrellaService {
 
         StoreMeta storeMeta = storeMetaService.findById(umbrellaRequest.getStoreMetaId());
 
-        if (umbrellaRepository.existsByUuid(umbrellaRequest.getUuid())) {
+        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid())) {
             throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
         }
 
@@ -48,10 +48,10 @@ public class UmbrellaService {
     public Umbrella modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
 
         StoreMeta storeMeta = storeMetaService.findById(umbrellaRequest.getStoreMetaId());
-        if (!umbrellaRepository.existsById(id)) {
+        if (!umbrellaRepository.existsByIdAndDeletedIsFalse(id)) {
             throw new IllegalArgumentException("[ERROR] 존재하지 않는 우산 고유번호입니다.");
         }
-        if (umbrellaRepository.existsByUuid(umbrellaRequest.getUuid())) {
+        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid())) {
             throw new IllegalArgumentException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
         }
 
@@ -65,7 +65,13 @@ public class UmbrellaService {
         );
     }
 
+    @Transactional
     public void deleteUmbrella(long id) {
+
+        // 이미 삭제된 경우도 포함
+        Umbrella foundUmbrella = umbrellaRepository.findByIdAndDeletedIsFalse(id)
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 우산 고유번호입니다."));
+        Umbrella.delete(foundUmbrella);
     }
 
 }

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -12,7 +12,6 @@ import upbrella.be.umbrella.service.UmbrellaService;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.mock;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
@@ -127,7 +126,8 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                 .rentable(true)
                 .build();
 
-        doNothing().when(umbrellaService).addUmbrella(umbrellaRequest);
+        given(umbrellaService.addUmbrella(umbrellaRequest))
+                .willReturn(null);
         // when
         mockMvc.perform(
                         post("/umbrellas")

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -1,6 +1,5 @@
 package upbrella.be.umbrella.service;
 
-import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +16,7 @@ import upbrella.be.umbrella.repository.UmbrellaRepository;
 
 import java.util.Optional;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
@@ -88,24 +88,21 @@ class UmbrellaServiceTest {
             Umbrella addedUmbrella = umbrellaService.addUmbrella(umbrellaRequest);
 
             // then
-            SoftAssertions softly = new SoftAssertions();
-            softly.assertThat(addedUmbrella.getUuid())
-                    .isEqualTo(43);
-            softly.assertThat(addedUmbrella.getStoreMeta().getId())
-                    .isEqualTo(2L);
-            softly.assertThat(addedUmbrella.getStoreMeta().getName())
-                    .isEqualTo("name");
-            softly.assertThat(addedUmbrella.getStoreMeta().getThumbnail())
-                    .isEqualTo("thumb");
-            softly.assertThat(addedUmbrella.getStoreMeta().isDeleted())
-                    .isEqualTo(false);
-            softly.assertThat(addedUmbrella.isRentable())
-                    .isEqualTo(true);
-            softly.assertThat(addedUmbrella.isDeleted())
-                    .isEqualTo(false);
-            softly.assertAll();
-
             assertAll(
+                    () -> assertThat(addedUmbrella.getUuid())
+                            .isEqualTo(43),
+                    () -> assertThat(addedUmbrella.getStoreMeta().getId())
+                            .isEqualTo(2L),
+                    () -> assertThat(addedUmbrella.getStoreMeta().getName())
+                            .isEqualTo("name"),
+                    () -> assertThat(addedUmbrella.getStoreMeta().getThumbnail())
+                            .isEqualTo("thumb"),
+                    () -> assertThat(addedUmbrella.getStoreMeta().isDeleted())
+                            .isEqualTo(false),
+                    () -> assertThat(addedUmbrella.isRentable())
+                            .isEqualTo(true),
+                    () -> assertThat(addedUmbrella.isDeleted())
+                            .isEqualTo(false),
                     () -> then(umbrellaRepository).should(times(1))
                             .existsByUuidAndDeletedIsFalse(43),
                     () -> then(storeMetaService).should(times(1))
@@ -208,24 +205,21 @@ class UmbrellaServiceTest {
             Umbrella modifiedUmbrella = umbrellaService.modifyUmbrella(1L, umbrellaRequest);
 
             // then
-            SoftAssertions softly = new SoftAssertions();
-            softly.assertThat(modifiedUmbrella.getUuid())
-                    .isEqualTo(50L);
-            softly.assertThat(modifiedUmbrella.getStoreMeta().getId())
-                    .isEqualTo(5L);
-            softly.assertThat(modifiedUmbrella.getStoreMeta().getName())
-                    .isEqualTo("연세대학교 파스쿠치");
-            softly.assertThat(modifiedUmbrella.getStoreMeta().getThumbnail())
-                    .isEqualTo("정면사진.jpg");
-            softly.assertThat(modifiedUmbrella.getStoreMeta().isDeleted())
-                    .isEqualTo(false);
-            softly.assertThat(modifiedUmbrella.isRentable())
-                    .isEqualTo(true);
-            softly.assertThat(modifiedUmbrella.isDeleted())
-                    .isEqualTo(false);
-            softly.assertAll();
-
             assertAll(
+                    () -> assertThat(modifiedUmbrella.getUuid())
+                            .isEqualTo(50L),
+                    () -> assertThat(modifiedUmbrella.getStoreMeta().getId())
+                            .isEqualTo(5L),
+                    () -> assertThat(modifiedUmbrella.getStoreMeta().getName())
+                            .isEqualTo("연세대학교 파스쿠치"),
+                    () -> assertThat(modifiedUmbrella.getStoreMeta().getThumbnail())
+                            .isEqualTo("정면사진.jpg"),
+                    () -> assertThat(modifiedUmbrella.getStoreMeta().isDeleted())
+                            .isEqualTo(false),
+                    () -> assertThat(modifiedUmbrella.isRentable())
+                            .isEqualTo(true),
+                    () -> assertThat(modifiedUmbrella.isDeleted())
+                            .isEqualTo(false),
                     () -> then(umbrellaRepository).should(times(1))
                             .existsByUuidAndDeletedIsFalse(50L),
                     () -> then(umbrellaRepository).should(times(1))
@@ -340,14 +334,11 @@ class UmbrellaServiceTest {
             umbrellaService.deleteUmbrella(1L);
 
             // then
-            SoftAssertions softly = new SoftAssertions();
-            softly.assertThat(umbrella.getId())
-                    .isEqualTo(1L);
-            softly.assertThat(umbrella.isDeleted())
-                    .isEqualTo(true);
-            softly.assertAll();
-
             assertAll(
+                    () -> assertThat(umbrella.getId())
+                            .isEqualTo(1L),
+                    () -> assertThat(umbrella.isDeleted())
+                            .isEqualTo(true),
                     () -> then(umbrellaRepository).should(times(1))
                             .findByIdAndDeletedIsFalse(1L)
             );


### PR DESCRIPTION
## 🟢 구현내용

- #39 

## 🧩 고민과 해결과정
- 삭제 기능 및 테스트 코드 추가했습니다.
- 피드백 바탕으로 assertAll()로 묶어서 한번에 실행되도록 설정
- 예외가 발생하는 경우 when과 then을 구분하기 힘들어서 묶어버렸는데 다른 좋은방법이 있을지 고민입니다.