### PR TITLE
[feat] 우산 전체 조회, 우산 지점 조회 기능 구현 및 테스트 코드 작성(#40, #41)

### DIFF
--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
@@ -2,6 +2,7 @@ package upbrella.be.umbrella.controller;
 
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
@@ -19,7 +20,7 @@ public class UmbrellaController {
     private final UmbrellaService umbrellaService;
 
     @GetMapping
-    public ResponseEntity<CustomResponse<UmbrellaPageResponse>> showAllUmbrellas(HttpSession httpSession) {
+    public ResponseEntity<CustomResponse<UmbrellaPageResponse>> showAllUmbrellas(Pageable pageable, HttpSession httpSession) {
 
         return ResponseEntity
                 .ok()
@@ -29,12 +30,12 @@ public class UmbrellaController {
                         "전체 우산 현황 조회 성공",
                         UmbrellaPageResponse.builder()
                                 .umbrellaResponsePage(
-                                        umbrellaService.findAllUmbrellas()
+                                        umbrellaService.findAllUmbrellas(pageable)
                 ).build()));
     }
 
     @GetMapping("/{storeId}")
-    public ResponseEntity<CustomResponse<UmbrellaPageResponse>> showUmbrellasByStoreId(HttpSession httpSession, @PathVariable long storeId) {
+    public ResponseEntity<CustomResponse<UmbrellaPageResponse>> showUmbrellasByStoreId(@PathVariable long storeId, Pageable pageable, HttpSession httpSession) {
 
         return ResponseEntity
                 .ok()
@@ -44,7 +45,7 @@ public class UmbrellaController {
                         "지점 우산 현황 조회 성공",
                         UmbrellaPageResponse.builder()
                                 .umbrellaResponsePage(
-                                        umbrellaService.findUmbrellasByStoreId(storeId)
+                                        umbrellaService.findUmbrellasByStoreId(storeId, pageable)
                                 ).build()));
     }
 

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -3,6 +3,7 @@ package upbrella.be.umbrella.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import upbrella.be.umbrella.entity.Umbrella;
 
 @Getter
 @Setter
@@ -13,4 +14,13 @@ public class UmbrellaResponse {
     private long storeMetaId;
     private long uuid;
     private boolean rentable;
+
+    public static UmbrellaResponse from(Umbrella umbrella) {
+        return UmbrellaResponse.builder()
+                .id(umbrella.getId())
+                .rentable(umbrella.isRentable())
+                .storeMetaId(umbrella.getStoreMeta().getId())
+                .uuid(umbrella.getUuid())
+                .build();
+    }
 }

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -15,7 +15,7 @@ public class Umbrella {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long id;
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "store_meta_id")
     private StoreMeta storeMeta;
     private long uuid;

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -1,8 +1,10 @@
 package upbrella.be.umbrella.repository;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.umbrella.entity.Umbrella;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
@@ -10,4 +12,6 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
     Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
     boolean existsByIdAndDeletedIsFalse(long id);
     boolean existsByUuidAndDeletedIsFalse(long uuid);
+    List<Umbrella> findByDeletedIsFalseOrderById(Pageable pageable);
+    List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -1,6 +1,7 @@
 package upbrella.be.umbrella.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
@@ -11,6 +12,7 @@ import upbrella.be.umbrella.repository.UmbrellaRepository;
 
 import javax.transaction.Transactional;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,12 +20,16 @@ public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
     private final StoreMetaService storeMetaService;
 
-    public List<UmbrellaResponse> findAllUmbrellas() {
-        return null;
+    public List<UmbrellaResponse> findAllUmbrellas(Pageable pageable) {
+        return umbrellaRepository.findByDeletedIsFalseOrderById(pageable)
+                .stream().map(UmbrellaResponse::from)
+                .collect(Collectors.toUnmodifiableList());
     }
 
-    public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId) {
-        return null;
+    public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId, Pageable pageable) {
+        return umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(storeId, pageable)
+                .stream().map(UmbrellaResponse::from)
+                .collect(Collectors.toUnmodifiableList());
     }
 
     @Transactional

--- a/src/test/java/upbrella/be/docs/utils/RestDocsSupport.java
+++ b/src/test/java/upbrella/be/docs/utils/RestDocsSupport.java
@@ -3,6 +3,7 @@ package upbrella.be.docs.utils;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.web.servlet.MockMvc;
@@ -19,6 +20,7 @@ public abstract class RestDocsSupport {
     @BeforeEach
     void setup(RestDocumentationContextProvider provider) {
         this.mockMvc = MockMvcBuilders.standaloneSetup(initController())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .apply(documentationConfiguration(provider))
                 .build();
     }

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -8,12 +8,17 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.repository.UmbrellaRepository;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -34,12 +39,144 @@ class UmbrellaServiceTest {
     @InjectMocks
     private UmbrellaService umbrellaService;
 
-    @Test
-    void findAllUmbrellas() {
+    @Nested
+    @DisplayName("페이지 번호와 페이지 크기를 입력받아")
+    class findAllUmbrellasTest {
+        private List<Umbrella> umbrellas = new ArrayList<>();
+        private StoreMeta storeMeta;
+        private UmbrellaResponse umbrellaResponse;
+
+        @BeforeEach
+        void setUp() {
+            storeMeta = StoreMeta.builder()
+                    .id(2L)
+                    .name("name")
+                    .thumbnail("thumb")
+                    .deleted(false)
+                    .build();
+
+            umbrellas.add(Umbrella.builder()
+                    .id(1L)
+                    .uuid(43L)
+                    .deleted(false)
+                    .storeMeta(storeMeta)
+                    .rentable(true)
+                    .build());
+
+            umbrellaResponse = UmbrellaResponse.builder()
+                    .id(1L)
+                    .uuid(43L)
+                    .storeMetaId(2L)
+                    .rentable(true)
+                    .build();
+        }
+
+        @DisplayName("해당하는 페이지의 우산 고유번호, 우산 관리번호, 협력 지점 고유번호, 대여 가능 여부를 포함하는 우산 목록 정보를 반환한다.")
+        @Test
+        void success() {
+
+            //given
+            Pageable pageable = PageRequest.of(0, 5);
+            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
+                    .willReturn(umbrellas);
+
+            //when
+            List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findAllUmbrellas(pageable);
+
+            //then
+            assertAll(
+                    () -> assertThat(umbrellaResponseList.size())
+                            .isEqualTo(1),
+                    () -> assertThat(umbrellaResponseList.get(0))
+                            .usingRecursiveComparison()
+                            .isEqualTo(umbrellaResponse)
+            );
+        }
+
+        @DisplayName("해당하는 우산이 없으면 빈 객체를 반환한다.")
+        @Test
+        void empty() {
+
+            //given
+            Pageable pageable = PageRequest.of(0, 5);
+            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
+                    .willReturn(List.of());
+
+            //when
+            List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findAllUmbrellas(pageable);
+
+            //then
+            assertThat(umbrellaResponseList).isEmpty();
+        }
     }
 
-    @Test
-    void findUmbrellasByStoreId() {
+    @Nested
+    @DisplayName("협력 지점의 고유번호와 페이지 번호, 페이지 크기를 입력받아")
+    class findUmbrellasByStoreIdTest {
+        private List<Umbrella> umbrellas = new ArrayList<>();
+        private StoreMeta storeMeta;
+        private UmbrellaResponse umbrellaResponse;
+        @BeforeEach
+        void setUp() {
+            storeMeta = StoreMeta.builder()
+                    .id(2L)
+                    .name("name")
+                    .thumbnail("thumb")
+                    .deleted(false)
+                    .build();
+
+            umbrellas.add(Umbrella.builder()
+                    .id(1L)
+                    .uuid(43L)
+                    .deleted(false)
+                    .storeMeta(storeMeta)
+                    .rentable(true)
+                    .build());
+
+            umbrellaResponse = UmbrellaResponse.builder()
+                    .id(1L)
+                    .uuid(43L)
+                    .storeMetaId(2L)
+                    .rentable(true)
+                    .build();
+        }
+
+        @DisplayName("해당하는 페이지의 우산 고유번호, 우산 관리번호, 협력 지점 고유번호, 대여 가능 여부를 포함하는 우산 목록 정보를 반환한다.")
+        @Test
+        void success() {
+            //given
+            Pageable pageable = PageRequest.of(0, 5);
+            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
+                    .willReturn(umbrellas);
+
+            //when
+            List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findUmbrellasByStoreId(2L, pageable);
+
+            //then
+            assertAll(
+                    () -> assertThat(umbrellaResponseList.size())
+                            .isEqualTo(1),
+                    () -> assertThat(umbrellaResponseList.get(0))
+                            .usingRecursiveComparison()
+                            .isEqualTo(umbrellaResponse)
+            );
+        }
+
+        @DisplayName("해당하는 우산이 없으면 빈 객체를 반환한다.")
+        @Test
+        void empty() {
+
+            //given
+            Pageable pageable = PageRequest.of(0, 5);
+            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
+                    .willReturn(List.of());
+
+            //when
+            List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findUmbrellasByStoreId(2L, pageable);
+
+            //then
+            assertThat(umbrellaResponseList).isEmpty();
+        }
     }
 
     @Nested


### PR DESCRIPTION
## 🟢 구현내용
- #40 
- #41 

## 🧩 고민과 해결과정
- Controller 테스트에서는 Json 직렬화, 역직렬화 과정에서 객체가 동등하더라도 참조 주소가 변합니다. Given에서 조건을 any()로 풀어주면 간단하지만 좀 더 엄밀한 테스팅을 위해서, mockito ArgumentMatchers의 reqEq를 이용해서 동등 비교를 할 수 있었습니다.  
- Service Layer 테스트에서는 Response의 모든 필드의 값을 하나씩 getter로 검증하기보다는 equals를 오버라이딩하지 않고 리플렉션으로 객체 동등성을 비교하게 해주는 AssertJ의 usingRecursiveComparision 메서드를 이용했습니다. 이를 통해 가독성을 개선했습니다. 
- RestAPI 현재 버전에는 Paging 기능이 반영되어있지 않은데, API 변경안이 결정되면 반영해서 수정하겠습니다.