### PR TITLE
[chore] PR 테스팅 자동화 스크립트 작성, 배포 스크립트 브랜치 별 분리

### DIFF
--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -3,6 +3,8 @@ name: Upbrella DEV PR Test
 on:
   pull_request:
     branches: [ "dev", "chore/#60-pr-test-automation" ]
+  push:
+    branches: ["chore/#60-pr-test-automation"]
 
 permissions:
   contents: read

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/labeler@v2
         with:
-          repo-token: ${{ secrets.ORG_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/labeler@v4
         with:
-          repo-token: ${{ secrets.ORG_TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches: [ "dev", "release-dev" ]
 
-#permissions:
-#  contents: read
-#  checks: write
-#  id-token: write
-#  pull-requests: write
+permissions:
+  contents: read
+  checks: write
+  id-token: write
+  pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,9 +17,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - uses: actions/labeler@v2
+      - uses: actions/labeler@v3
         with:
-          repo-token: ${{ secrets.TOKEN }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+#      - uses: actions/labeler@v4
+#        with:
+#          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,7 +2,7 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "dev", "chore/#60-pr-test-automation" ]
 
 permissions:
   contents: read

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,9 +2,7 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev" ]
-  push:
-    branches: [ "chore/#60-pr-test-automation" ]
+    branches: [ "dev", "release-dev" ]
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,7 +2,7 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev" ]
+    branches: [ "dev", "release-dev", "release-production" ]
 
 jobs:
     test:

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -4,16 +4,18 @@ on:
   pull_request:
     branches: [ "dev", "release-dev" ]
 
-permissions:
-  contents: read
-  pull-requests: write
-
 jobs:
   test:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - name: checkout
         uses: actions/checkout@v3
+
+      - name: Get registration token
+        id: getRegToken
+        run: |
+          curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TOKEN }}
 
 
       - name: 🐳 테스트 실패 Comment
@@ -44,4 +44,4 @@ jobs:
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -4,11 +4,11 @@ on:
   pull_request:
     branches: [ "dev", "release-dev" ]
 
-permissions:
-  contents: read
-  checks: write
-  id-token: write
-  pull-requests: write
+#permissions:
+#  contents: read
+#  checks: write
+#  id-token: write
+#  pull-requests: write
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/labeler@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -9,51 +9,46 @@ permissions:
   pull-requests: write
 
 jobs:
-  print-token:
-    permissions: write-all
-    name: print-token
-    environment: dev
-    # needs: pre-pkr
-    runs-on: ubuntu-latest
+    test:
+      permissions: write-all
+      environment: dev
+      runs-on: ubuntu-latest
+      steps:
+        - name: Check out code
+          uses: actions/checkout@v2
 
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
+        - name: Get registration token
+          id: getRegToken
+          run: |
+            curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
 
-      - name: Get registration token
-        id: getRegToken
-        run: |
-          curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - name: checkout
-        uses: actions/checkout@v3
+        - name: checkout
+          uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
+        - name: Set up JDK 11
+          uses: actions/setup-java@v3
+          with:
+            java-version: '11'
+            distribution: 'adopt'
 
-      - name: Set application properties
-        run: |
-          touch src/main/resources/application.properties
-          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
+        - name: Set application properties
+          run: |
+            touch src/main/resources/application.properties
+            echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
 
-      - name: Test with Gradle
-        run: |
-          chmod +x gradlew
-          ./gradlew --info test
+        - name: Test with Gradle
+          run: |
+            chmod +x gradlew
+            ./gradlew --info test
 
-      - name: 🐳 테스트 결과 Report
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: ${{ always() }}
-        with:
-          files: 'build/test-results/**/*.xml'
+        - name: 🐳 테스트 결과 Report
+          uses: EnricoMi/publish-unit-test-result-action@v2
+          if: ${{ always() }}
+          with:
+            files: 'build/test-results/**/*.xml'
 
-      - name: 🐳 테스트 실패 Comment
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: 'build/test-results/test/TEST-*.xml'
+        - name: 🐳 테스트 실패 Comment
+          uses: mikepenz/action-junit-report@v3
+          if: always()
+          with:
+            report_paths: 'build/test-results/test/TEST-*.xml'

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [ "dev", "release-dev", "release-production" ]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
     test:
       permissions: write-all

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,53 +2,45 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev", "release-dev", "release-production" ]
+    branches: [ "dev", "release-dev" ]
 
 permissions:
   contents: read
   pull-requests: write
 
 jobs:
-    test:
-      permissions: write-all
-      environment: dev
-      runs-on: ubuntu-latest
-      steps:
-        - name: Check out code
-          uses: actions/checkout@v2
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-        - name: Get registration token
-          id: getRegToken
-          run: |
-            curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
+      - name: checkout
+        uses: actions/checkout@v3
 
-        - name: checkout
-          uses: actions/checkout@v3
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
 
-        - name: Set up JDK 11
-          uses: actions/setup-java@v3
-          with:
-            java-version: '11'
-            distribution: 'adopt'
+      - name: Set application properties
+        run: |
+          touch src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
+      - name: Test with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew --info test
+      - name: 🐳 테스트 결과 Report
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: ${{ always() }}
+        with:
+          files: 'build/test-results/**/*.xml'
 
-        - name: Set application properties
-          run: |
-            touch src/main/resources/application.properties
-            echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
-
-        - name: Test with Gradle
-          run: |
-            chmod +x gradlew
-            ./gradlew --info test
-
-        - name: 🐳 테스트 결과 Report
-          uses: EnricoMi/publish-unit-test-result-action@v2
-          if: ${{ always() }}
-          with:
-            files: 'build/test-results/**/*.xml'
-
-        - name: 🐳 테스트 실패 Comment
-          uses: mikepenz/action-junit-report@v3
-          if: always()
-          with:
-            report_paths: 'build/test-results/test/TEST-*.xml'
+      - name: 🐳 테스트 실패 Comment
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'build/test-results/test/TEST-*.xml'

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -9,13 +9,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  print-token:
+    permissions: write-all
+    name: print-token
+    environment: dev
+    # needs: pre-pkr
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Get registration token
+        id: getRegToken
+        run: |
+          curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -16,12 +16,6 @@ jobs:
         id: getRegToken
         run: |
           curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
-          curl -L \
-            -X POST \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer TOKEN" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/OWNER/REPO/actions/runners/registration-token
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -31,7 +25,7 @@ jobs:
       - name: Set application properties
         run: |
           touch src/main/resources/application.properties
-          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
       - name: Test with Gradle
         run: |
           chmod +x gradlew

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -36,7 +36,7 @@ jobs:
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
-          github_token: ${{ secrets.TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
 
       - name: 🐳 테스트 실패 Comment
@@ -44,4 +44,4 @@ jobs:
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
-          github_token: ${{ secrets.TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -6,20 +6,18 @@ on:
 
 permissions:
   contents: read
-  checks: write
-  id-token: write
   pull-requests: write
+
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout
         uses: actions/checkout@v3
-
-      - uses: actions/labeler@v3
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -12,9 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -16,7 +16,12 @@ jobs:
         id: getRegToken
         run: |
           curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
-
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer TOKEN" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/OWNER/REPO/actions/runners/registration-token
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,11 +2,7 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev", "chore/#60-pr-test-automation" ]
-
-permissions:
-  contents: read
-  pull-requests: write
+    branches: [ "dev" ]
 
 jobs:
     test:

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -17,8 +17,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Use the fine grain token
-        run: echo ${{ secrets.ORG_TOKEN }}
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.ORG_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -12,10 +12,6 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/labeler@v4
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-
       - name: checkout
         uses: actions/checkout@v3
 
@@ -33,15 +29,19 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew --info test
+          
 
       - name: 🐳 테스트 결과 Report
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
 
       - name: 🐳 테스트 실패 Comment
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Set application properties
       run: |
         touch src/main/resources/application.properties
-        echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.properties
+        echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
      
     - name: Test with Gradle
       run: |

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -6,8 +6,9 @@ on:
 
 permissions:
   contents: read
+  checks: write
+  id-token: write
   pull-requests: write
-
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -3,7 +3,8 @@ name: Upbrella DEV PR Test
 on:
   pull_request:
     branches: [ "dev", "release-dev", "chore/#60-pr-test-automation" ]
-
+  push:
+    branches: [ "chore/#60-pr-test-automation" ]
 jobs:
   test:
     permissions: write-all

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,7 +2,7 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev", "release-dev" ]
+    branches: [ "dev", "release-dev", "chore/#60-pr-test-automation" ]
 
 jobs:
   test:

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -35,8 +35,7 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew --info test
-        with:
-          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}
+
       - name: 🐳 테스트 결과 Report
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ always() }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,10 +2,8 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev", "chore/#60-pr-test-automation" ]
-  push:
-    branches: ["chore/#60-pr-test-automation"]
-# 확인
+    branches: [ "dev" ]
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -17,6 +17,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
+      - name: Use the fine grain token
+        run: echo ${{ secrets.ORG_TOKEN }}
+
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -3,7 +3,8 @@ name: Upbrella DEV PR Test
 on:
   pull_request:
     branches: [ "dev" ]
-
+  push:
+    branches: [ "chore/#60-pr-test-automation" ]
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -35,14 +35,18 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew --info test
+        with:
+          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}
       - name: 🐳 테스트 결과 Report
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
+          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}
 
       - name: 🐳 테스트 실패 Comment
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
+          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -6,39 +6,43 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: checkout
-      uses: actions/checkout@v3
+      - name: checkout
+        uses: actions/checkout@v3
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'adopt'
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
 
-    - name: Set application properties
-      run: |
-        touch src/main/resources/application.properties
-        echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
-     
-    - name: Test with Gradle
-      run: |
-        chmod +x gradlew
-        ./gradlew --info test
+      - name: Set application properties
+        run: |
+          touch src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
 
-    - name: 🐳 테스트 결과 Report
-      uses: EnricoMi/publish-unit-test-result-action@v2
-      if: ${{ always() }}
-      with:
-        files: 'build/test-results/**/*.xml'
+      - name: Test with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew --info test
 
-    - name: 🐳 테스트 실패 Comment
-      uses: mikepenz/action-junit-report@v3
-      if: always()
-      with:
-        report_paths: 'build/test-results/test/TEST-*.xml'
+      - name: 🐳 테스트 결과 Report
+        uses: EnricoMi/publish-unit-test-result-action@v2
+        if: ${{ always() }}
+        with:
+          files: 'build/test-results/**/*.xml'
+
+      - name: 🐳 테스트 실패 Comment
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: 'build/test-results/test/TEST-*.xml'

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -17,9 +17,9 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - uses: actions/labeler@v4
+      - uses: actions/labeler@v2
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          repo-token: ${{ secrets.ORG_TOKEN }}
 
       - name: Set up JDK 11
         uses: actions/setup-java@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -14,9 +14,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-#      - uses: actions/labeler@v4
-#        with:
-#          repo-token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: checkout
         uses: actions/checkout@v3

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -36,9 +36,11 @@ jobs:
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}
 
       - name: 🐳 테스트 실패 Comment
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
+          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -2,21 +2,23 @@ name: Upbrella DEV PR Test
 
 on:
   pull_request:
-    branches: [ "dev", "release-dev", "chore/#60-pr-test-automation" ]
-  push:
-    branches: [ "chore/#60-pr-test-automation" ]
+    branches: [ "dev", "chore/#60-pr-test-automation" ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
-    permissions: write-all
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/labeler@v4
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Get registration token
-        id: getRegToken
-        run: |
-          curl -X POST -H \"Accept: application/vnd.github.v3+json\"  -H 'Authorization: token ${{ secrets.GITHUB_TOKEN }}' https://api.github.com/repos/myprofile/myrepo/actions/runners/registration-token
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
@@ -26,24 +28,19 @@ jobs:
       - name: Set application properties
         run: |
           touch src/main/resources/application.properties
-          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
       - name: Test with Gradle
         run: |
           chmod +x gradlew
           ./gradlew --info test
-          
-
       - name: 🐳 테스트 결과 Report
         uses: EnricoMi/publish-unit-test-result-action@v2
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
 
       - name: 🐳 테스트 실패 Comment
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
-          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "dev", "chore/#60-pr-test-automation" ]
   push:
     branches: ["chore/#60-pr-test-automation"]
-
+# 확인
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -1,0 +1,38 @@
+name: Upbrella DEV PR Test
+
+on:
+  pull_request:
+    branches: [ "dev" ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: checkout
+      uses: actions/checkout@v3
+
+    - name: Set up JDK 11
+      uses: actions/setup-java@v3
+      with:
+        java-version: '11'
+        distribution: 'adopt'
+
+    - name: Set application properties
+      run: |
+        touch src/main/resources/application.properties
+        echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.properties
+     
+    - name: Test with Gradle
+      run: |
+        chmod +x gradlew
+        ./gradlew --info test
+
+    - name: 🐳 테스트 결과 Report
+      uses: EnricoMi/publish-unit-test-result-action@v2
+      if: ${{ always() }}
+      with:
+        files: 'build/test-results/**/*.xml'

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -42,11 +42,9 @@ jobs:
         if: ${{ always() }}
         with:
           files: 'build/test-results/**/*.xml'
-          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}
 
       - name: 🐳 테스트 실패 Comment
         uses: mikepenz/action-junit-report@v3
         if: always()
         with:
           report_paths: 'build/test-results/test/TEST-*.xml'
-          GITHUB_TOKEN: ${{ secrets.ORG_TOKEN }}

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -36,3 +36,9 @@ jobs:
       if: ${{ always() }}
       with:
         files: 'build/test-results/**/*.xml'
+
+    - name: 🐳 테스트 실패 Comment
+      uses: mikepenz/action-junit-report@v3
+      if: always()
+      with:
+        report_paths: 'build/test-results/test/TEST-*.xml'

--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -31,16 +31,3 @@ jobs:
         run: |
           chmod +x gradlew
           ./gradlew --info test
-      - name: 🐳 테스트 결과 Report
-        uses: EnricoMi/publish-unit-test-result-action@v2
-        if: ${{ always() }}
-        with:
-          files: 'build/test-results/**/*.xml'
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}
-
-      - name: 🐳 테스트 실패 Comment
-        uses: mikepenz/action-junit-report@v3
-        if: always()
-        with:
-          report_paths: 'build/test-results/test/TEST-*.xml'
-          GITHUB_TOKEN: ${{ secrets.TOKEN }}

--- a/.github/workflows/dev-release-ci.yml
+++ b/.github/workflows/dev-release-ci.yml
@@ -2,8 +2,7 @@ name: Upbrella DEV CI
 
 on:
   push:
-    branches: [ "feat/#9-CICD-setting" ]
-    
+    branches: [ "release-dev" ]
 
 env:
   WORKING_DIRECTORY: ./

--- a/.github/workflows/production-release-ci.yml
+++ b/.github/workflows/production-release-ci.yml
@@ -2,13 +2,13 @@ name: Upbrella DEV CI
 
 on:
   push:
-    branches: [ "release-dev" ]
+    branches: [ "release-production" ]
 
 env:
   WORKING_DIRECTORY: ./
   DOCKERFILE_DIRECTORY: ./.github/workflows
-  CODE_DEPLOY_APPLICATION_NAME: upbrella-dev-deploy
-  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: UpbrellaServerDev
+  CODE_DEPLOY_APPLICATION_NAME: upbrella-production-deploy
+  CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: UpbrellaServerProduction
   S3_BUCKET_NAME: upbrella-storage
 
 permissions:
@@ -31,7 +31,7 @@ jobs:
     - name: Set application properties
       run: |
         touch src/main/resources/application.properties
-        echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" | base64 --decode > src/main/resources/application.properties
+        echo "${{ secrets.APPLICATION_PROPERTIES }}" | base64 --decode > src/main/resources/application.properties
      
     - name: Build with Gradle
       run: |


### PR DESCRIPTION
## 🟢 구현내용
- #60 
https://github.com/UPbrella/UPbrella_back/pull/69/files
## 🧩 고민과 해결과정
- dev 브랜치, release-dev, release-production에 pr 올렸을 때 자동으로 테스트 실행되도록 스크립트 수정했습니다.
- 배포 스크립트 release-dev, release-production 파일 분리했습니다. properties 키도 분리했으며 별도 등록 필요합니다.
- 코드, 시크릿이 완전 동일한데도 오리진에서는 성공하고 업스트림에서는 계속 실패해서 한참 찾아보았습니다. 알게된것은 깃헙 정책상 organization에 소속되어있지 않은 개인 계정으로 fork한 레퍼지토리에서 PR을 보내면 Github actions에서 secret을 가져와서 사용하게해주지 않습니다.. 이거때문에 새벽3시까지 5시간동안 디버깅했네요. 결론은 organization 내에서 fork해서 PR을 올려야 PR올릴때 테스팅이 가능하다!입니다. 시크릿이 필요없는 테스트면 상관없는데 JDBC 연결때문에 지금은 빌드가 안되서 테스트가 터졌었구요
- 일단은 그래서 가설이 맞는지 확인하기 위해 예외적으로 upstream에 브랜치 하나 푸시해서 PR 올렸습니다 
- 설정파일 없이 테스트가 모두 돌아가게 설정하면 가능할거같은데 통합 테스팅도 필요하기 때문에.. PR 테스팅을 적용할지말지 내일 논의해보시죠..