### PR TITLE
[feat] 현재 위치(지도) 기준 협업 지점 조회 기능 구현 및 테스트 코드 작성 (#70)

### DIFF
--- a/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
+++ b/src/main/java/upbrella/be/store/StoreRepository/StoreMetaRepository.java
@@ -3,8 +3,10 @@ package upbrella.be.store.StoreRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.store.entity.StoreMeta;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface StoreMetaRepository extends JpaRepository<StoreMeta, Long> {
     Optional<StoreMeta> findByIdAndDeletedIsFalse(long id);
+    List<StoreMeta> findAllByDeletedIsFalseAndLatitudeBetweenAndLongitudeBetween(double latitudeFrom, double latitudeTo, double longitudeFrom, double longitudeTo);
 }

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -1,19 +1,23 @@
 package upbrella.be.store.controller;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 import upbrella.be.store.dto.request.CoordinateRequest;
 import upbrella.be.store.dto.request.CreateStoreRequest;
 import upbrella.be.store.dto.response.*;
+import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.util.CustomResponse;
 
 import javax.servlet.http.HttpSession;
 import java.util.List;
 
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/stores")
 public class StoreController {
+    private final StoreMetaService storeMetaService;
 
     @GetMapping("/{storeId}")
     public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(HttpSession session, @PathVariable long storeId) {
@@ -47,14 +51,7 @@ public class StoreController {
                         200,
                         "현재 위치 기준 가게 조회 성공",
                         AllCurrentLocationStoreResponse.builder()
-                                .stores(List.of(
-                                        SingleCurrentLocationStoreResponse.builder()
-                                                .id(1)
-                                                .name("업브렐라")
-                                                .latitude(37.503716)
-                                                .longitude(127.053718)
-                                                .openStatus(true)
-                                                .build()))
+                                .stores(storeMetaService.findStoresInCurrentMap(coordinateRequest))
                                 .build()));
     }
 

--- a/src/main/java/upbrella/be/store/dto/request/CoordinateRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/CoordinateRequest.java
@@ -1,17 +1,16 @@
 package upbrella.be.store.dto.request;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Setter
 public class CoordinateRequest {
 
-    private double latitude;
-    private double longitude;
-    private int zoomLevel;
+    private double latitudeFrom;
+    private double latitudeTo;
+    private double longitudeFrom;
+    private double longitudeTo;
 }

--- a/src/main/java/upbrella/be/store/dto/response/SingleCurrentLocationStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleCurrentLocationStoreResponse.java
@@ -2,6 +2,7 @@ package upbrella.be.store.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import upbrella.be.store.entity.StoreMeta;
 
 @Getter
 @Builder
@@ -12,4 +13,14 @@ public class SingleCurrentLocationStoreResponse {
     private boolean openStatus;
     private double latitude;
     private double longitude;
+
+    public static SingleCurrentLocationStoreResponse fromStoreMeta(StoreMeta storeMeta) {
+        return SingleCurrentLocationStoreResponse.builder()
+                .id(storeMeta.getId())
+                .name(storeMeta.getName())
+                .openStatus(storeMeta.isActivated())
+                .latitude(storeMeta.getLatitude())
+                .longitude(storeMeta.getLongitude())
+                .build();
+    }
 }

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -1,8 +1,6 @@
 package upbrella.be.store.entity;
 
 import lombok.*;
-import org.hibernate.annotations.SQLDelete;
-import org.hibernate.annotations.Where;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -11,10 +9,8 @@ import javax.persistence.Id;
 @Entity
 @Getter
 @Builder
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "UPDATE storeMeta SET deleted = true WHERE id = ?")
-@Where(clause = "deleted = false")
 public class StoreMeta {
 
     @Id
@@ -24,4 +20,6 @@ public class StoreMeta {
     private String thumbnail;
     private boolean activated;
     private boolean deleted;
+    private double latitude;
+    private double longitude;
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -24,7 +24,7 @@ public class StoreMetaService {
     public List<SingleCurrentLocationStoreResponse> findStoresInCurrentMap(CoordinateRequest coordinateRequest) {
         List<StoreMeta> storeMetaListInCurrentMap = storeMetaRepository.findAllByDeletedIsFalseAndLatitudeBetweenAndLongitudeBetween(
                 coordinateRequest.getLatitudeFrom(), coordinateRequest.getLatitudeTo(),
-                coordinateRequest.getLatitudeFrom(), coordinateRequest.getLatitudeTo()
+                coordinateRequest.getLongitudeFrom(), coordinateRequest.getLongitudeTo()
         );
 
         return storeMetaListInCurrentMap.stream()

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -3,7 +3,12 @@ package upbrella.be.store.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import upbrella.be.store.StoreRepository.StoreMetaRepository;
+import upbrella.be.store.dto.request.CoordinateRequest;
+import upbrella.be.store.dto.response.SingleCurrentLocationStoreResponse;
 import upbrella.be.store.entity.StoreMeta;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -11,7 +16,19 @@ public class StoreMetaService {
     private final StoreMetaRepository storeMetaRepository;
 
     public StoreMeta findById(long id) {
+
         return storeMetaRepository.findByIdAndDeletedIsFalse(id)
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
+    }
+
+    public List<SingleCurrentLocationStoreResponse> findStoresInCurrentMap(CoordinateRequest coordinateRequest) {
+        List<StoreMeta> storeMetaListInCurrentMap = storeMetaRepository.findAllByDeletedIsFalseAndLatitudeBetweenAndLongitudeBetween(
+                coordinateRequest.getLatitudeFrom(), coordinateRequest.getLatitudeTo(),
+                coordinateRequest.getLatitudeFrom(), coordinateRequest.getLatitudeTo()
+        );
+
+        return storeMetaListInCurrentMap.stream()
+                .map(SingleCurrentLocationStoreResponse::fromStoreMeta)
+                .collect(Collectors.toUnmodifiableList());
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -15,7 +15,7 @@ public class UmbrellaResponse {
     private long uuid;
     private boolean rentable;
 
-    public static UmbrellaResponse from(Umbrella umbrella) {
+    public static UmbrellaResponse fromUmbrella(Umbrella umbrella) {
         return UmbrellaResponse.builder()
                 .id(umbrella.getId())
                 .rentable(umbrella.isRentable())

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -22,13 +22,13 @@ public class UmbrellaService {
 
     public List<UmbrellaResponse> findAllUmbrellas(Pageable pageable) {
         return umbrellaRepository.findByDeletedIsFalseOrderById(pageable)
-                .stream().map(UmbrellaResponse::from)
+                .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toUnmodifiableList());
     }
 
     public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId, Pageable pageable) {
         return umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(storeId, pageable)
-                .stream().map(UmbrellaResponse::from)
+                .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toUnmodifiableList());
     }
 

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -2,15 +2,23 @@ package upbrella.be.store.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.restdocs.payload.JsonFieldType;
 import upbrella.be.docs.utils.RestDocsSupport;
+import upbrella.be.store.dto.request.CoordinateRequest;
 import upbrella.be.store.dto.request.CreateStoreRequest;
 import upbrella.be.store.dto.request.UpdateStoreRequest;
+import upbrella.be.store.dto.response.SingleCurrentLocationStoreResponse;
+import upbrella.be.store.service.StoreMetaService;
 
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -20,12 +28,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentRequest;
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
+@ExtendWith(MockitoExtension.class)
 class StoreControllerTest extends RestDocsSupport {
 
+    @Mock
+    StoreMetaService storeMetaService;
 
     @Override
     protected Object initController() {
-        return new StoreController();
+        return new StoreController(storeMetaService);
     }
 
     @Test
@@ -75,18 +86,31 @@ class StoreControllerTest extends RestDocsSupport {
     @Test
     @DisplayName("사용자는 우산의 위도, 경도, 확대 정도를 기반으로 협업지점을 조회할 수 있다.")
     void test() throws Exception {
+
         // given
+        final double latitudeFrom = 37.5666103;
+        final double latitudeTo = 77.5666103;
+        final double longitudeFrom = 36.9783882;
+        final double longitudeTo = 126.9783882;
 
+        given(storeMetaService.findStoresInCurrentMap(any(CoordinateRequest.class)))
+                .willReturn(
+                        List.of(
+                                SingleCurrentLocationStoreResponse.builder()
+                                        .id(1)
+                                        .name("업브렐라")
+                                        .latitude(37.503716)
+                                        .longitude(127.053718)
+                                        .openStatus(true)
+                                        .build()));
 
-        // when
-
-
-        // then
+        // when & then
         mockMvc.perform(
                         get("/stores/location")
-                                .param("latitude", "37.5666103")
-                                .param("longitude", "126.9783882")
-                                .param("zoomLevel", "1")
+                                .param("latitudeFrom", String.valueOf(latitudeFrom))
+                                .param("latitudeTo", String.valueOf(latitudeTo))
+                                .param("longitudeFrom", String.valueOf(longitudeFrom))
+                                .param("longitudeTo", String.valueOf(longitudeTo))
                                 .contentType(MediaType.APPLICATION_JSON)
                 ).andDo(print())
                 .andExpect(status().isOk())
@@ -94,12 +118,14 @@ class StoreControllerTest extends RestDocsSupport {
                         getDocumentRequest(),
                         getDocumentResponse(),
                         requestParameters(
-                                parameterWithName("latitude")
-                                        .description("위도"),
-                                parameterWithName("longitude")
-                                        .description("경도"),
-                                parameterWithName("zoomLevel")
-                                        .description("확대 정도")
+                                parameterWithName("latitudeFrom")
+                                        .description("위도 경계 시작"),
+                                parameterWithName("latitudeTo")
+                                        .description("위도 경계 종료"),
+                                parameterWithName("longitudeFrom")
+                                        .description("경도 경계 시작"),
+                                parameterWithName("longitudeTo")
+                                        .description("경도 경계 종료")
                         ),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -1,0 +1,104 @@
+package upbrella.be.store.service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import upbrella.be.store.StoreRepository.StoreMetaRepository;
+import upbrella.be.store.dto.request.CoordinateRequest;
+import upbrella.be.store.dto.response.SingleCurrentLocationStoreResponse;
+import upbrella.be.store.entity.StoreMeta;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class StoreMetaServiceTest {
+
+    @Mock
+    private StoreMetaRepository storeMetaRepository;
+
+    @InjectMocks
+    private StoreMetaService storeMetaService;
+
+    @Test
+    void findById() {
+    }
+
+    @Nested
+    @DisplayName("현재 지도 상에 보이는 위도, 경도 범위를 입력받아")
+    class findStoresInCurrentMapTest {
+        private List<StoreMeta> storeMetaList = new ArrayList<>();
+
+        private SingleCurrentLocationStoreResponse response;
+
+        @BeforeEach
+        void setUp() {
+            StoreMeta storeIn = StoreMeta.builder()
+                    .id(1)
+                    .latitude(4)
+                    .longitude(3)
+                    .build();
+
+            StoreMeta storeOut = StoreMeta.builder()
+                    .id(1)
+                    .latitude(6)
+                    .longitude(3)
+                    .build();
+
+            response = SingleCurrentLocationStoreResponse.builder()
+                    .id(1)
+                    .latitude(4)
+                    .longitude(3)
+                    .build();
+
+            storeMetaList.add(storeIn);
+        }
+
+        @Test
+        @DisplayName("지도 상의 협업 지점 정보를 성공적으로 반환한다.")
+        void success() {
+
+            //given
+            given(storeMetaRepository.findAllByDeletedIsFalseAndLatitudeBetweenAndLongitudeBetween(3.0, 5.0, 2.0, 4.0))
+                    .willReturn(storeMetaList);
+
+            //when
+            List<SingleCurrentLocationStoreResponse> storesInCurrentMap = storeMetaService.findStoresInCurrentMap(new CoordinateRequest(3.0, 5.0, 2.0, 4.0));
+
+            //then
+            assertAll(
+                    () -> assertThat(storesInCurrentMap.size())
+                            .isEqualTo(1),
+                    () -> assertThat(storesInCurrentMap.get(0))
+                            .usingRecursiveComparison()
+                            .isEqualTo(response)
+            );
+        }
+
+        @Test
+        @DisplayName("만족하는 협업 지점이 없으면 빈 리스트를 반환한다.")
+        void empty() {
+
+            //given
+            given(storeMetaRepository.findAllByDeletedIsFalseAndLatitudeBetweenAndLongitudeBetween(3.0, 5.0, 2.0, 4.0))
+                    .willReturn(List.of());
+
+            //when
+            List<SingleCurrentLocationStoreResponse> storesInCurrentMap = storeMetaService.findStoresInCurrentMap(new CoordinateRequest(3.0, 5.0, 2.0, 4.0));
+
+            //then
+            assertThat(storesInCurrentMap.size())
+                            .isEqualTo(0);
+        }
+    }
+
+}

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -44,12 +44,20 @@ class StoreMetaServiceTest {
         void setUp() {
             StoreMeta storeIn = StoreMeta.builder()
                     .id(1)
+                    .thumbnail("사진1")
+                    .name("모티브 카페 신촌 지점")
+                    .activated(true)
+                    .deleted(false)
                     .latitude(4)
                     .longitude(3)
                     .build();
 
             StoreMeta storeOut = StoreMeta.builder()
                     .id(1)
+                    .thumbnail("사진2")
+                    .name("모티브 카페 미국 지점")
+                    .activated(true)
+                    .deleted(false)
                     .latitude(6)
                     .longitude(3)
                     .build();
@@ -58,6 +66,8 @@ class StoreMetaServiceTest {
                     .id(1)
                     .latitude(4)
                     .longitude(3)
+                    .name("모티브 카페 신촌 지점")
+                    .openStatus(true)
                     .build();
 
             storeMetaList.add(storeIn);


### PR DESCRIPTION
## 🟢 구현내용
- #70
 
## 🧩 고민과 해결과정
- [지도 경계 좌표 확인 API](https://navermaps.github.io/maps.js.ncp/docs/tutorial-4-map-bounds.example.html)가 있어서 이 기능으로 API를 구현하면 훨씬 편리하여 API 명세 변경이 필요해보이고 일단 이에 맞춰서 기능 구현 했습니다.
- All-args 생성자를 열긴했는데 필드 개수가 아주 많은 경우나 nullable 필드가 많은 경우 빌더 대비 all-args의 가독성이 확떨어지는 경우가 있어서 무조건 all-args를 사용해야할까요? 일단 기존 방식대로 builder로 테스트코드를 작성하긴했습니다.