### PR TITLE
[feat] JACOCO 도입 (#79)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,80 +1,121 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '2.7.13'
-	id 'io.spring.dependency-management' version '1.0.15.RELEASE'
-	id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'java'
+    id 'org.springframework.boot' version '2.7.13'
+    id 'io.spring.dependency-management' version '1.0.15.RELEASE'
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+    id 'jacoco'
 }
 
 group = 'upbrella-server-dev'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	sourceCompatibility = '11'
+    sourceCompatibility = '11'
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
-	asciidoctorExt
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+    asciidoctorExt
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 ext {
-	set('snippetsDir', file("build/generated-snippets"))
+    set('snippetsDir', file("build/generated-snippets"))
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
     testImplementation 'org.projectlombok:lombok:1.18.26'
     compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 
-	//RestDocs
-	asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
-	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    //RestDocs
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 ext {
-	snippetsDir = file('../build/generated-snippets')
+    snippetsDir = file('../build/generated-snippets')
 }
 
 test {
-	outputs.dir snippetsDir
+    outputs.dir snippetsDir
 }
 
 asciidoctor {
-	inputs.dir snippetsDir
-	configurations 'asciidoctorExt'
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
 
-	sources {
-		include("**/index.adoc")
-	}
-	baseDirFollowsSourceFile()
+    sources {
+        include("**/index.adoc")
+    }
+    baseDirFollowsSourceFile()
 
-	dependsOn test
+    dependsOn test
 }
 
 bootJar {
-	dependsOn asciidoctor
-	from("${asciidoctor.outputDir}") {
-		into 'static/docs'
-	}
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }
 
 tasks.named('test') {
-	outputs.dir snippetsDir
-	useJUnitPlatform()
+    outputs.dir snippetsDir
+    useJUnitPlatform()
 }
 
 tasks.named('asciidoctor') {
-	inputs.dir snippetsDir
-	dependsOn test
+    inputs.dir snippetsDir
+    dependsOn test
+}
+
+test {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    toolVersion = "0.8.5"
+}
+
+jacocoTestReport {
+    reports {
+        // 원하는 리포트를 켜고 끌 수 있습니다.
+        html.required.set(true)
+        xml.required.set(false)
+        csv.required.set(false)
+
+//  각 리포트 타입 마다 리포트 저장 경로를 설정할 수 있습니다.
+//  html.destination file("$buildDir/jacocoHtml")
+//  xml.destination file("$buildDir/jacoco.xml")
+    }
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS'
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.00
+            }
+
+            excludes = []
+
+        }
+    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -49,6 +49,8 @@ ext {
 
 test {
     outputs.dir snippetsDir
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -80,11 +82,6 @@ tasks.named('asciidoctor') {
     dependsOn test
 }
 
-test {
-    useJUnitPlatform()
-    finalizedBy 'jacocoTestReport'
-}
-
 jacoco {
     toolVersion = "0.8.5"
 }
@@ -95,10 +92,6 @@ jacocoTestReport {
         html.required.set(true)
         xml.required.set(false)
         csv.required.set(false)
-
-//  각 리포트 타입 마다 리포트 저장 경로를 설정할 수 있습니다.
-//  html.destination file("$buildDir/jacocoHtml")
-//  xml.destination file("$buildDir/jacoco.xml")
     }
     finalizedBy 'jacocoTestCoverageVerification'
 }
@@ -112,6 +105,7 @@ jacocoTestCoverageVerification {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
                 minimum = 0.00
+                // 최소 커버리지 비율 설정 -> 임시로 0% 설정
             }
 
             excludes = []


### PR DESCRIPTION
## 🟢 구현내용
- #79 
 
## 🧩 고민과 해결과정
- 생각보다 간단하게 설정되어서 올려봅니다. build.gradle에 추가만해주면 거의 설정할게 없더군요.
- 사용방법은 test를 실행시키면 test -> testReport -> testCoverageVerification이 순서대로 동작하면서 build/reports/test/html/index.html에 테스트 커버리지 리포트가 생성됩니다. 테스트 결과 리포트는 build/reports/tests/test/index.html에 생성됩니다.
- Build 실패가 되도록 설정할 수 있는데(주석 부분) 특정 클래스가 현재 0% 커버리지인게 있어서 설정이안되어 일단 비활성화 해두었습니다.
- 코드 커버리지가 무엇인지는 [이 글](https://hudi.blog/code-coverage/)에 잘 나와있습니다. 커버리지가 높다는 것은 테스트가 프로덕션 코드의 인스트럭션을 많이 실행한다는 것이지 제대로 테스트가 된다는 보장은 아니라고 합니다.