### PR TITLE
[feat] 로그인한 사용자 정보 조회, 로그인한 사용자가 대여 중인 우산 정보 조회 구현 및 테스트 작성 (#74, #75)

### DIFF
--- a/src/main/java/upbrella/be/rent/repository/RentRepository.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepository.java
@@ -3,6 +3,9 @@ package upbrella.be.rent.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.rent.entity.History;
 
+import java.util.Optional;
+
 public interface RentRepository extends JpaRepository<History, Long> {
 
+    Optional<History> findByUserAndReturnedAtIsNull(Long userId);
 }

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -26,6 +26,8 @@ public class RentService {
     @Transactional
     public void addRental(RentUmbrellaByUserRequest rentUmbrellaByUserRequest, User userToRent) {
 
+        // 사용자가 이미 대여 중인 우산이 있으면 대여하지 못하도록 예외 처리
+
         Umbrella willRentUmbrella = umbrellaRepository.findByUuidAndDeletedIsFalse(rentUmbrellaByUserRequest.getUuid())
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 해당 우산이 존재하지 않습니다."));
 

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -5,6 +5,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import upbrella.be.rent.entity.History;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.umbrella.repository.UmbrellaRepository;
 import upbrella.be.user.dto.response.UmbrellaBorrowedByUserResponse;
@@ -58,13 +59,16 @@ public class UserController {
 
         // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
         User loggedInUser = User.builder()
-                .id(1L)
+                .id(72L)
                 .name("사용자")
-                .phoneNumber("010-0000-0000")
+                .phoneNumber("010-1234-5678")
                 .adminStatus(false)
                 .build();
 
+        History rentalHistory = rentRepository.findByUserAndReturnedAtIsNull(loggedInUser.getId())
+                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자가 빌린 우산이 없습니다."));
 
+        long borredUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
 
         return ResponseEntity
                 .ok()
@@ -73,7 +77,7 @@ public class UserController {
                         200,
                         "사용자가 빌린 우산 조회 성공",
                         UmbrellaBorrowedByUserResponse.builder()
-                                .id(1L)
+                                .uuid(borredUmbrellaUuid)
                                 .build()));
     }
 }

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -5,6 +5,8 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import upbrella.be.rent.repository.RentRepository;
+import upbrella.be.umbrella.repository.UmbrellaRepository;
 import upbrella.be.user.dto.response.UmbrellaBorrowedByUserResponse;
 import upbrella.be.user.dto.response.UserInfoResponse;
 import upbrella.be.user.entity.User;
@@ -19,6 +21,7 @@ import javax.servlet.http.HttpSession;
 public class UserController {
 
     private final UserService userService;
+    private final RentRepository rentRepository;
 
     @GetMapping
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
@@ -47,6 +50,22 @@ public class UserController {
 
     @GetMapping("/umbrella")
     public ResponseEntity<CustomResponse<UmbrellaBorrowedByUserResponse>> findUmbrellaBorrowedByUser(HttpSession httpSession) {
+
+        /**
+         * TODO: 세션 처리으로 로그인한 유저의 id 가져오기
+         *       interceptor에서 userId를 가져올 것인지, user 객체를 가져올 것인지 논의 후 구현
+         */
+
+        // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
+        User loggedInUser = User.builder()
+                .id(1L)
+                .name("사용자")
+                .phoneNumber("010-0000-0000")
+                .adminStatus(false)
+                .build();
+
+
+
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -21,7 +21,6 @@ import javax.servlet.http.HttpSession;
 @RequiredArgsConstructor
 public class UserController {
 
-    private final UserService userService;
     private final RentRepository rentRepository;
 
     @GetMapping

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -23,7 +23,10 @@ public class UserController {
     @GetMapping
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
 
-        // TODO: 세션 처리으로 로그인한 유저의 id 가져오기
+        /**
+         * TODO: 세션 처리으로 로그인한 유저의 id 가져오기
+         *       interceptor에서 userId를 가져올 것인지, user 객체를 가져올 것인지 논의 후 구현
+         */
 
         // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
         User loggedInUser = User.builder()
@@ -39,12 +42,7 @@ public class UserController {
                         "success",
                         200,
                         "로그인 유저 정보 조회 성공",
-                        UserInfoResponse.builder()
-                                .id(1)
-                                .name("사용자")
-                                .phoneNumber("010-0000-0000")
-                                .adminStatus(false)
-                                .build()));
+                        UserInfoResponse.fromUser(loggedInUser)));
     }
 
     @GetMapping("/umbrella")

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import upbrella.be.user.dto.response.UmbrellaBorrowedByUserResponse;
 import upbrella.be.user.dto.response.UserInfoResponse;
+import upbrella.be.user.entity.User;
 import upbrella.be.user.service.UserService;
 import upbrella.be.util.CustomResponse;
 
@@ -21,6 +22,17 @@ public class UserController {
 
     @GetMapping
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
+
+        // TODO: 세션 처리으로 로그인한 유저의 id 가져오기
+
+        // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
+        User loggedInUser = User.builder()
+                .id(1L)
+                .name("사용자")
+                .phoneNumber("010-0000-0000")
+                .adminStatus(false)
+                .build();
+
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -68,7 +68,7 @@ public class UserController {
         History rentalHistory = rentRepository.findByUserAndReturnedAtIsNull(loggedInUser.getId())
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자가 빌린 우산이 없습니다."));
 
-        long borredUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
+        long borrowedUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
 
         return ResponseEntity
                 .ok()
@@ -77,7 +77,7 @@ public class UserController {
                         200,
                         "사용자가 빌린 우산 조회 성공",
                         UmbrellaBorrowedByUserResponse.builder()
-                                .uuid(borredUmbrellaUuid)
+                                .uuid(borrowedUmbrellaUuid)
                                 .build()));
     }
 }

--- a/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
@@ -9,5 +9,5 @@ import lombok.Setter;
 @Builder
 public class UmbrellaBorrowedByUserResponse {
 
-    private long id;
+    private long uuid;
 }

--- a/src/main/java/upbrella/be/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/UserInfoResponse.java
@@ -3,6 +3,7 @@ package upbrella.be.user.dto.response;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
+import upbrella.be.user.entity.User;
 
 @Getter
 @Setter
@@ -12,5 +13,12 @@ public class UserInfoResponse {
     private long id;
     private String name;
     private String phoneNumber;
-    private boolean adminStatus;
+
+    public static UserInfoResponse fromUser(User user) {
+        return UserInfoResponse.builder()
+                .id(user.getId())
+                .name(user.getName())
+                .phoneNumber(user.getPhoneNumber())
+                .build();
+    }
 }

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -53,9 +53,7 @@ public class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("name").type(JsonFieldType.STRING)
                                         .description("사용자 이름"),
                                 fieldWithPath("phoneNumber").type(JsonFieldType.STRING)
-                                        .description("사용자 전화번호"),
-                                fieldWithPath("adminStatus").type(JsonFieldType.BOOLEAN)
-                                        .description("관리자 여부")
+                                        .description("사용자 전화번호")
                         )));
     }
 

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -2,6 +2,7 @@ package upbrella.be.user.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.springframework.restdocs.payload.JsonFieldType;
 import upbrella.be.docs.utils.RestDocsSupport;
 import upbrella.be.rent.entity.History;
@@ -26,8 +27,10 @@ import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
 public class UserControllerTest extends RestDocsSupport {
 
-    private final UserService userService = mock(UserService.class);
-    private final RentRepository rentRepository = mock(RentRepository.class);
+    @Mock
+    private UserService userService;
+    @Mock
+    private RentRepository rentRepository;
 
     @Override
     protected Object initController() {

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -2,7 +2,9 @@ package upbrella.be.user.controller;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.restdocs.payload.JsonFieldType;
 import upbrella.be.docs.utils.RestDocsSupport;
 import upbrella.be.rent.entity.History;
@@ -25,16 +27,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentRequest;
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
+@ExtendWith(MockitoExtension.class)
 public class UserControllerTest extends RestDocsSupport {
 
-    @Mock
-    private UserService userService;
     @Mock
     private RentRepository rentRepository;
 
     @Override
     protected Object initController() {
-        return new UserController(userService, rentRepository);
+        return new UserController(rentRepository);
     }
 
     @DisplayName("사용자는 유저 정보를 조회할 수 있다.")
@@ -81,8 +82,6 @@ public class UserControllerTest extends RestDocsSupport {
                 .umbrella(borrowedUmbrella)
                 .build();
 
-        given(userService.findUmbrellaBorrowedByUser(anyLong()))
-                .willReturn(1L);
         given(rentRepository.findByUserAndReturnedAtIsNull(anyLong()))
                 .willReturn(Optional.ofNullable(rentalHistory));
 

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -36,7 +36,6 @@ public class UserControllerTest extends RestDocsSupport {
                 .id(1)
                 .name("일반사용자")
                 .phoneNumber("010-0000-0000")
-                .adminStatus(false)
                 .build();
 
         // when


### PR DESCRIPTION
## 🟢 구현내용
- #74 
- #75 
 
## 🧩 고민과 해결과정
- session에서 userId를 가져오게 될텐데 service layer로 userId만 넘겨줄 것인지, user 객체를 넘겨줄 것인지 정하고 진행하면 좋을 것같습니다.
- 로그인한 사용자가 대여 중인 우산 정보를 조회하는 거는 mypage에서 필요한 것같은데 일단 API DOCS에 있는대로 uuid만 만들었지만, uuid말고 다른 데이터도 필요할 것같아서 얘기해봐야 할 것같습니다.