### PR TITLE
[feat] 대여 폼으로 이동 시 자동 완성에 필요한 데이터 fetch 기능 구현 및 테스트 작성 (#124)

### DIFF
--- a/src/docs/asciidoc/api/rent/rent.adoc
+++ b/src/docs/asciidoc/api/rent/rent.adoc
@@ -1,3 +1,13 @@
+=== 대여 폼 데이터 조회
+==== HTTP Request
+
+include::{snippets}/find-rental-form-doc/http-request.adoc[]
+include::{snippets}/find-rental-form-doc/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/find-rental-form-doc/http-response.adoc[]
+include::{snippets}/find-rental-form-doc/response-fields-data.adoc[]
+
 === 우산 대여 신청
 ==== HTTP Request
 

--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -31,12 +31,15 @@ public class RentController {
     @GetMapping("/form/{umbrellaId}")
     public ResponseEntity<CustomResponse<RentFormResponse>> findRentForm(@PathVariable long umbrellaId, HttpSession httpSession) {
 
+        RentFormResponse rentForm = rentService.findRentForm(umbrellaId);
+
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
                         "success",
                         200,
-                        "대여 폼 조회 성공"
+                        "대여 폼 조회 성공",
+                        rentForm
                 ));
     }
 

--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -28,6 +28,18 @@ public class RentController {
     // 가짜 유저 사용을 위해 임시로 UserRepository 주입
     private final UserRepository userRepository;
 
+    @GetMapping("/form/{umbrellaId}")
+    public ResponseEntity<CustomResponse<RentFormResponse>> findRentForm(@PathVariable long umbrellaId, HttpSession httpSession) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "대여 폼 조회 성공"
+                ));
+    }
+
     @PostMapping
     public ResponseEntity<CustomResponse> rentUmbrellaByUser(@RequestBody RentUmbrellaByUserRequest rentUmbrellaByUserRequest, HttpSession httpSession) {
 

--- a/src/main/java/upbrella/be/rent/dto/response/RentFormResponse.java
+++ b/src/main/java/upbrella/be/rent/dto/response/RentFormResponse.java
@@ -2,6 +2,7 @@ package upbrella.be.rent.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import upbrella.be.umbrella.entity.Umbrella;
 
 @Getter
 @Builder
@@ -10,5 +11,15 @@ public class RentFormResponse {
     private String classificationName;
     private String rentStoreName;
     private long umbrellaUuid;
-    private long password;
+    private String password;
+
+    public static RentFormResponse of(Umbrella umbrella) {
+
+        return RentFormResponse.builder()
+                .classificationName(umbrella.getStoreMeta().getClassification().getName())
+                .rentStoreName(umbrella.getStoreMeta().getName())
+                .umbrellaUuid(umbrella.getUuid())
+                .password(umbrella.getStoreMeta().getPassword())
+                .build();
+    }
 }

--- a/src/main/java/upbrella/be/rent/dto/response/RentFormResponse.java
+++ b/src/main/java/upbrella/be/rent/dto/response/RentFormResponse.java
@@ -1,0 +1,14 @@
+package upbrella.be.rent.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class RentFormResponse {
+
+    private String classificationName;
+    private String rentStoreName;
+    private long umbrellaUuid;
+    private long password;
+}

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
+import upbrella.be.rent.dto.response.RentFormResponse;
 import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
 import upbrella.be.rent.dto.response.RentalHistoryResponse;
 import upbrella.be.rent.entity.History;
@@ -28,6 +29,14 @@ public class RentService {
     private final UmbrellaService umbrellaService;
     private final StoreMetaService storeMetaService;
     private final RentRepository rentRepository;
+
+    public RentFormResponse findRentForm(long umbrellaId) {
+
+        Umbrella umbrella = umbrellaService.findUmbrellaById(umbrellaId);
+
+        return RentFormResponse.of(umbrella);
+    }
+
 
     @Transactional
     public History addRental(RentUmbrellaByUserRequest rentUmbrellaByUserRequest, User userToRent) {

--- a/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
+++ b/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
@@ -49,8 +49,9 @@ public class RentControllerTest extends RestDocsSupport {
         return new RentController(conditionReportService, improvementReportService, rentService, userRepository);
     }
 
-    @DisplayName("사용자는 우산 대여 요청을 할 수 있다.")
+
     @Test
+    @DisplayName("사용자는 우산 대여 요청을 할 수 있다.")
     void rentUmbrellaTest() throws Exception {
 
         RentUmbrellaByUserRequest request = RentUmbrellaByUserRequest.builder()
@@ -93,8 +94,8 @@ public class RentControllerTest extends RestDocsSupport {
                 ));
     }
 
-    @DisplayName("사용자는 우산 반납 요청을 할 수 있다.")
     @Test
+    @DisplayName("사용자는 우산 반납 요청을 할 수 있다.")
     void returnUmbrellaTest() throws Exception {
         ReturnUmbrellaByUserRequest request = ReturnUmbrellaByUserRequest.builder()
                 .uuid(1)
@@ -123,8 +124,8 @@ public class RentControllerTest extends RestDocsSupport {
                 ));
     }
 
-    @DisplayName("사용자는 우산 대여 내역을 조회 할 수 있다.")
     @Test
+    @DisplayName("사용자는 우산 대여 내역을 조회 할 수 있다.")
     void showAllRentalHistoriesTest() throws Exception {
 
         RentalHistoriesPageResponse response = RentalHistoriesPageResponse.builder()
@@ -194,8 +195,8 @@ public class RentControllerTest extends RestDocsSupport {
                         )));
     }
 
-    @DisplayName("사용자는 신고 내역을 조회할 수 있다.")
     @Test
+    @DisplayName("사용자는 신고 내역을 조회할 수 있다.")
     void showAllStatusConditionTest() throws Exception {
 
         ConditionReportPageResponse conditionReportsResponse = ConditionReportPageResponse.builder()
@@ -235,8 +236,8 @@ public class RentControllerTest extends RestDocsSupport {
 
     }
 
-    @DisplayName("사용자는 개선 요청 내역을 조회할 수 있다.")
     @Test
+    @DisplayName("사용자는 개선 요청 내역을 조회할 수 있다.")
     void showAllImprovementsTest() throws Exception {
 
         ImprovementReportPageResponse improvementReportsResponse = ImprovementReportPageResponse.builder()

--- a/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
+++ b/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
@@ -27,6 +27,8 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentRequest;
@@ -49,6 +51,46 @@ public class RentControllerTest extends RestDocsSupport {
         return new RentController(conditionReportService, improvementReportService, rentService, userRepository);
     }
 
+    @Test
+    @DisplayName("사용자는 대여 폼 자동 완성에 필요한 데이터를 조회할 수 있다.")
+    void findRentalFormTest() throws Exception {
+
+        // given
+        RentFormResponse rentFormResponse = RentFormResponse.builder()
+                .classificationName("신촌")
+                .rentStoreName("motive study cafe")
+                .umbrellaUuid(99L)
+                .password("1234")
+                .build();
+
+        given(rentService.findRentForm(2L))
+                .willReturn(rentFormResponse);
+
+        // when & then
+        mockMvc.perform(
+                        get("/rent/form/{umbrellaId}", 2L)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-rental-form-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("umbrellaId")
+                                        .description("우산 번호 (uuid 아님)")
+                        ),
+                        responseFields(
+                                beneathPath("data")
+                                        .withSubsectionId("data"),
+                                fieldWithPath("classificationName").type(JsonFieldType.STRING)
+                                        .description("지역"),
+                                fieldWithPath("rentStoreName").type(JsonFieldType.STRING)
+                                        .description("대여 지점 이름"),
+                                fieldWithPath("umbrellaUuid").type(JsonFieldType.NUMBER)
+                                        .description("우산 고유번호"),
+                                fieldWithPath("password").type(JsonFieldType.STRING)
+                                        .description("비밀번호")
+                        )));
+    }
 
     @Test
     @DisplayName("사용자는 우산 대여 요청을 할 수 있다.")


### PR DESCRIPTION
## 🟢 구현내용

- #124 

## 🧩 고민과 해결과정

- 자동 완성되는 데이터 중 사용자에 대한 정보도 있지만, 로그인한 유저 정보 조회 API는 따로 있으므로 response에 유저 정보는 담지 않았습니다.
- 위와 같이 store에 대한 정보도 마찬가지로 umbrellaId를 통해 조회한는 API가 있지만 해당 API에 password는 없으므로 response에 담았습니다.