### PR TITLE
[feat] 우산 어드민 전체 통계, 지점 통계 구현 및 테스트 코드 작성 (#141, #142)

### DIFF
--- a/src/docs/asciidoc/api/umbrella/umbrella.adoc
+++ b/src/docs/asciidoc/api/umbrella/umbrella.adoc
@@ -42,3 +42,19 @@ include::{snippets}/delete-umbrella-doc/http-request.adoc[]
 
 include::{snippets}/delete-umbrella-doc/path-parameters.adoc[]
 
+=== 우산 전체 통계 조회
+==== HTTP Request
+
+include::{snippets}/show-all-umbrellas-statistics-doc/http-request.adoc[]
+==== HTTP Response
+include::{snippets}/show-all-umbrellas-statistics-doc/http-response.adoc[]
+include::{snippets}/show-all-umbrellas-statistics-doc/response-fields-data.adoc[]
+
+
+=== 우산 지점 통계 조회
+==== HTTP Request
+
+include::{snippets}/show-umbrellas-statistics-by-store-doc/http-request.adoc[]
+==== HTTP Response
+include::{snippets}/show-umbrellas-statistics-by-store-doc/http-response.adoc[]
+include::{snippets}/show-umbrellas-statistics-by-store-doc/response-fields-data.adoc[]

--- a/src/main/java/upbrella/be/rent/repository/RentRepository.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepository.java
@@ -10,4 +10,7 @@ public interface RentRepository extends JpaRepository<History, Long>, RentReposi
     Optional<History> findByUserAndReturnedAtIsNull(Long userId);
 
     Optional<History> findByUserIdAndReturnedAtIsNull(Long userId);
+
+    long countByRentStoreMetaId(long storeId);
+
 }

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -148,4 +148,12 @@ public class RentService {
 
         return RentalHistoryResponse.createNonReturnedHistory(history, elapsedDay, isReturned);
     }
+
+    public long countTotalRent() {
+        return rentRepository.count();
+    }
+
+    public long countTotalRentByStoreId(long storeId) {
+        return rentRepository.countByRentStoreMetaId(storeId);
+    }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
+++ b/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import upbrella.be.store.exception.DeletedStoreDetailException;
 import upbrella.be.store.exception.NonExistingStoreDetailException;
+import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.util.CustomErrorResponse;
 
 @RestControllerAdvice
@@ -12,6 +13,17 @@ public class StoreExceptionHandler {
 
     @ExceptionHandler(NonExistingStoreDetailException.class)
     public ResponseEntity<CustomErrorResponse> nonExistingStoreDetail(NonExistingStoreDetailException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "fail",
+                        400,
+                        "존재하지 않는 협업지점 상세 고유번호입니다."));
+    }
+
+    @ExceptionHandler(NonExistingStoreMetaException.class)
+    public ResponseEntity<CustomErrorResponse> nonExistingStoreDetail(NonExistingStoreMetaException ex) {
 
         return ResponseEntity
                 .badRequest()

--- a/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
@@ -14,12 +14,12 @@ public class StoreFindByIdResponse {
     private String businessHours;
     private String contactNumber;
     private String address;
-    private int availableUmbrellaCount;
+    private long availableUmbrellaCount;
     private boolean openStatus;
     private double latitude;
     private double longitude;
 
-    public static StoreFindByIdResponse fromStoreDetail(StoreDetail storeDetail, int availableUmbrellaCount) {
+    public static StoreFindByIdResponse fromStoreDetail(StoreDetail storeDetail, long availableUmbrellaCount) {
 
         return StoreFindByIdResponse.builder()
                 .id(storeDetail.getId())

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -62,7 +62,7 @@ public class StoreDetailService {
         StoreDetail storeDetail = storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeMetaId)
                 .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 해당하는 협업 지점이 존재하지 않습니다."));
 
-        int availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeMetaId);
+        long availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeMetaId);
 
         return StoreFindByIdResponse.fromStoreDetail(storeDetail, availableUmbrellaCount);
     }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -125,6 +125,7 @@ public class StoreMetaService {
     }
 
     public boolean existByStoreId(long storeId) {
+
         return storeMetaRepository.existsById(storeId);
     }
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -123,4 +123,8 @@ public class StoreMetaService {
 
         storeDetailRepository.save(StoreDetail.createForSave(store, storeMeta));
     }
+
+    public boolean existByStoreId(long storeId) {
+        return storeMetaRepository.existsById(storeId);
+    }
 }

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
@@ -6,6 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.response.UmbrellaAllStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaPageResponse;
 import upbrella.be.umbrella.service.UmbrellaService;
 import upbrella.be.util.CustomResponse;
@@ -86,5 +87,17 @@ public class UmbrellaController {
                         200,
                         "우산 삭제 성공",
                         null));
+    }
+
+    @GetMapping("/statistics")
+    public ResponseEntity<CustomResponse<UmbrellaAllStatisticsResponse>> showAllUmbrellasStatistics(HttpSession httpSession) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "전체 우산 통계 조회 성공",
+                        umbrellaService.getUmbrellaAllStatistics()));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
@@ -5,7 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaPageResponse;
 import upbrella.be.umbrella.service.UmbrellaService;
@@ -51,9 +52,9 @@ public class UmbrellaController {
     }
 
     @PostMapping
-    public ResponseEntity<CustomResponse> addUmbrella(HttpSession httpSession, @RequestBody UmbrellaRequest umbrellaRequest) {
+    public ResponseEntity<CustomResponse> addUmbrella(HttpSession httpSession, @RequestBody UmbrellaCreateRequest umbrellaCreateRequest) {
 
-        umbrellaService.addUmbrella(umbrellaRequest);
+        umbrellaService.addUmbrella(umbrellaCreateRequest);
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
@@ -64,9 +65,9 @@ public class UmbrellaController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<CustomResponse> modifyUmbrella(HttpSession httpSession, @RequestBody UmbrellaRequest umbrellaRequest, @PathVariable long id) {
+    public ResponseEntity<CustomResponse> modifyUmbrella(HttpSession httpSession, @RequestBody UmbrellaModifyRequest umbrellaModifyRequest, @PathVariable long id) {
 
-        umbrellaService.modifyUmbrella(id, umbrellaRequest);
+        umbrellaService.modifyUmbrella(id, umbrellaModifyRequest);
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
@@ -52,7 +52,7 @@ public class UmbrellaController {
     }
 
     @PostMapping
-    public ResponseEntity<CustomResponse> addUmbrella(HttpSession httpSession, @RequestBody UmbrellaCreateRequest umbrellaCreateRequest) {
+    public ResponseEntity<CustomResponse> addUmbrella(@RequestBody UmbrellaCreateRequest umbrellaCreateRequest, HttpSession httpSession) {
 
         umbrellaService.addUmbrella(umbrellaCreateRequest);
         return ResponseEntity
@@ -65,7 +65,7 @@ public class UmbrellaController {
     }
 
     @PatchMapping("/{id}")
-    public ResponseEntity<CustomResponse> modifyUmbrella(HttpSession httpSession, @RequestBody UmbrellaModifyRequest umbrellaModifyRequest, @PathVariable long id) {
+    public ResponseEntity<CustomResponse> modifyUmbrella(@RequestBody UmbrellaModifyRequest umbrellaModifyRequest, @PathVariable long id, HttpSession httpSession) {
 
         umbrellaService.modifyUmbrella(id, umbrellaModifyRequest);
         return ResponseEntity
@@ -78,7 +78,7 @@ public class UmbrellaController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<CustomResponse> deleteUmbrella(HttpSession httpSession, @PathVariable long id) {
+    public ResponseEntity<CustomResponse> deleteUmbrella(@PathVariable long id, HttpSession httpSession) {
 
         umbrellaService.deleteUmbrella(id);
         return ResponseEntity
@@ -103,7 +103,7 @@ public class UmbrellaController {
     }
 
     @GetMapping("/statistics/{storeId}")
-    public ResponseEntity<CustomResponse<UmbrellaStatisticsResponse>> showUmbrellasStatisticsByStore(HttpSession httpSession, @PathVariable long storeId) {
+    public ResponseEntity<CustomResponse<UmbrellaStatisticsResponse>> showUmbrellasStatisticsByStore(@PathVariable long storeId, HttpSession httpSession) {
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaController.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
-import upbrella.be.umbrella.dto.response.UmbrellaAllStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaPageResponse;
 import upbrella.be.umbrella.service.UmbrellaService;
 import upbrella.be.util.CustomResponse;
@@ -90,7 +90,7 @@ public class UmbrellaController {
     }
 
     @GetMapping("/statistics")
-    public ResponseEntity<CustomResponse<UmbrellaAllStatisticsResponse>> showAllUmbrellasStatistics(HttpSession httpSession) {
+    public ResponseEntity<CustomResponse<UmbrellaStatisticsResponse>> showAllUmbrellasStatistics(HttpSession httpSession) {
 
         return ResponseEntity
                 .ok()
@@ -99,5 +99,17 @@ public class UmbrellaController {
                         200,
                         "전체 우산 통계 조회 성공",
                         umbrellaService.getUmbrellaAllStatistics()));
+    }
+
+    @GetMapping("/statistics/{storeId}")
+    public ResponseEntity<CustomResponse<UmbrellaStatisticsResponse>> showUmbrellasStatisticsByStore(HttpSession httpSession, @PathVariable long storeId) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "지점 우산 통계 조회 성공",
+                        umbrellaService.getUmbrellaStatisticsByStoreId(storeId)));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/request/UmbrellaCreateRequest.java
+++ b/src/main/java/upbrella/be/umbrella/dto/request/UmbrellaCreateRequest.java
@@ -1,0 +1,14 @@
+package upbrella.be.umbrella.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UmbrellaCreateRequest {
+
+    private long storeMetaId;
+    private long uuid;
+    private boolean rentable;
+}

--- a/src/main/java/upbrella/be/umbrella/dto/request/UmbrellaModifyRequest.java
+++ b/src/main/java/upbrella/be/umbrella/dto/request/UmbrellaModifyRequest.java
@@ -6,10 +6,11 @@ import lombok.*;
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class UmbrellaRequest {
+
+public class UmbrellaModifyRequest {
 
     private long storeMetaId;
     private long uuid;
     private boolean rentable;
-
+    private boolean missed;
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaAllStatisticsResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaAllStatisticsResponse.java
@@ -1,0 +1,26 @@
+package upbrella.be.umbrella.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class UmbrellaAllStatisticsResponse {
+
+    private int totalUmbrellaCount;
+    private int rentableUmbrellaCount;
+    private int rentedUmbrellaCount;
+    private int missingUmbrellaCount;
+    private double missingRate;
+
+    public static UmbrellaAllStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount, int rentedUmbrellaCount, int missingUmbrellaCount) {
+
+        return UmbrellaAllStatisticsResponse.builder()
+                .totalUmbrellaCount(totalUmbrellaCount)
+                .rentableUmbrellaCount(rentableUmbrellaCount)
+                .rentedUmbrellaCount(rentedUmbrellaCount)
+                .missingUmbrellaCount(missingUmbrellaCount)
+                .missingRate((double) 100*missingUmbrellaCount / totalUmbrellaCount)
+                .build();
+    }
+}

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
@@ -7,15 +7,15 @@ import lombok.Getter;
 @Builder
 public class UmbrellaStatisticsResponse {
 
-    private int totalUmbrellaCount;
-    private int rentableUmbrellaCount;
-    private int rentedUmbrellaCount;
-    private int missingUmbrellaCount;
+    private long totalUmbrellaCount;
+    private long rentableUmbrellaCount;
+    private long rentedUmbrellaCount;
+    private long missingUmbrellaCount;
     private double missingRate;
     private long totalRentCount;
 
-    public static UmbrellaStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount,
-                                                        int rentedUmbrellaCount, int missingUmbrellaCount,
+    public static UmbrellaStatisticsResponse fromCounts(long totalUmbrellaCount, long rentableUmbrellaCount,
+                                                        long rentedUmbrellaCount, long missingUmbrellaCount,
                                                         long totalRentCount) {
 
         return UmbrellaStatisticsResponse.builder()

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
@@ -12,15 +12,19 @@ public class UmbrellaStatisticsResponse {
     private int rentedUmbrellaCount;
     private int missingUmbrellaCount;
     private double missingRate;
+    private long totalRentCount;
 
-    public static UmbrellaStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount, int rentedUmbrellaCount, int missingUmbrellaCount) {
+    public static UmbrellaStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount,
+                                                        int rentedUmbrellaCount, int missingUmbrellaCount,
+                                                        long totalRentCount) {
 
         return UmbrellaStatisticsResponse.builder()
                 .totalUmbrellaCount(totalUmbrellaCount)
                 .rentableUmbrellaCount(rentableUmbrellaCount)
                 .rentedUmbrellaCount(rentedUmbrellaCount)
                 .missingUmbrellaCount(missingUmbrellaCount)
-                .missingRate((double) 100*missingUmbrellaCount / totalUmbrellaCount)
+                .missingRate((double) 100 * missingUmbrellaCount / totalUmbrellaCount)
+                .totalRentCount(totalRentCount)
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaStatisticsResponse.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class UmbrellaAllStatisticsResponse {
+public class UmbrellaStatisticsResponse {
 
     private int totalUmbrellaCount;
     private int rentableUmbrellaCount;
@@ -13,9 +13,9 @@ public class UmbrellaAllStatisticsResponse {
     private int missingUmbrellaCount;
     private double missingRate;
 
-    public static UmbrellaAllStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount, int rentedUmbrellaCount, int missingUmbrellaCount) {
+    public static UmbrellaStatisticsResponse fromCounts(int totalUmbrellaCount, int rentableUmbrellaCount, int rentedUmbrellaCount, int missingUmbrellaCount) {
 
-        return UmbrellaAllStatisticsResponse.builder()
+        return UmbrellaStatisticsResponse.builder()
                 .totalUmbrellaCount(totalUmbrellaCount)
                 .rentableUmbrellaCount(rentableUmbrellaCount)
                 .rentedUmbrellaCount(rentedUmbrellaCount)

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -2,7 +2,8 @@ package upbrella.be.umbrella.entity;
 
 import lombok.*;
 import upbrella.be.store.entity.StoreMeta;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 
 import javax.persistence.*;
 
@@ -22,29 +23,32 @@ public class Umbrella {
     private long uuid;
     private boolean rentable;
     private boolean deleted;
+    private boolean missed;
 
     public void delete() {
         this.deleted = true;
     }
 
-    public static Umbrella ofCreated(UmbrellaRequest umbrellaRequest, StoreMeta storeMeta) {
+    public static Umbrella ofCreated(UmbrellaCreateRequest umbrellaCreateRequest, StoreMeta storeMeta) {
 
         return Umbrella.builder()
                 .storeMeta(storeMeta)
-                .uuid(umbrellaRequest.getUuid())
-                .rentable(umbrellaRequest.isRentable())
+                .uuid(umbrellaCreateRequest.getUuid())
+                .rentable(umbrellaCreateRequest.isRentable())
                 .deleted(false)
+                .missed(false)
                 .build();
     }
 
-    public static Umbrella ofUpdated(long id, UmbrellaRequest umbrellaRequest, StoreMeta storeMeta) {
+    public static Umbrella ofUpdated(long id, UmbrellaModifyRequest umbrellaModifyRequest, StoreMeta storeMeta) {
 
         return Umbrella.builder()
                 .id(id)
                 .storeMeta(storeMeta)
-                .uuid(umbrellaRequest.getUuid())
-                .rentable(umbrellaRequest.isRentable())
+                .uuid(umbrellaModifyRequest.getUuid())
+                .rentable(umbrellaModifyRequest.isRentable())
                 .deleted(false)
+                .missed(umbrellaModifyRequest.isMissed())
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -22,4 +22,13 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
     List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
 
     int countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(long storeMetaId);
+
+    int countUmbrellasByRentableIsTrueAndDeletedIsFalse();
+
+    int countUmbrellasByRentableIsFalseAndDeletedIsFalse();
+
+    int countUmbrellaBy();
+
+    int countUmbrellasByAndDeletedIsTrue();
+
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -7,7 +7,7 @@ import upbrella.be.umbrella.entity.Umbrella;
 import java.util.List;
 import java.util.Optional;
 
-public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
+public interface UmbrellaRepository extends JpaRepository<Umbrella, Long>, UmbrellaRepositoryCustom {
 
     Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
 
@@ -19,27 +19,5 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
 
     List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
 
-    // 대여가능 우산 조회
-    int countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse();
 
-    // 대여중인 우산 조회
-    int countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse();
-
-    // 전체 우산 조회
-    int countUmbrellaByDeletedIsFalse();
-
-    // 분실 우산 조회
-    int countUmbrellasByMissedIsTrueAndDeletedIsFalse();
-
-    // 지점 대여 가능 우산 조회
-    int countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(long storeMetaId);
-
-    // 지점 대여중인 우산 조회
-    int countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(long storeMetaId);
-
-    // 지점 전체 우산 조회
-    int countUmbrellaByStoreMetaIdAndDeletedIsFalse(long storeId);
-
-    // 지점 분실 우산 조회
-    int countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(long storeId);
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -11,8 +11,6 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
 
     Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
 
-    Optional<Umbrella> findByUuidAndDeletedIsFalse(long uuid);
-
     boolean existsByIdAndDeletedIsFalse(long id);
 
     boolean existsByUuidAndDeletedIsFalse(long uuid);
@@ -31,4 +29,9 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
 
     int countUmbrellasByAndDeletedIsTrue();
 
+    int countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(long storeMetaId);
+
+    int countUmbrellaByStoreMetaId(long storeId);
+
+    int countUmbrellasByStoreMetaIdAndDeletedIsTrue(long storeId);
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -19,19 +19,27 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long> {
 
     List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
 
-    int countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(long storeMetaId);
+    // 대여가능 우산 조회
+    int countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse();
 
-    int countUmbrellasByRentableIsTrueAndDeletedIsFalse();
+    // 대여중인 우산 조회
+    int countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse();
 
-    int countUmbrellasByRentableIsFalseAndDeletedIsFalse();
+    // 전체 우산 조회
+    int countUmbrellaByDeletedIsFalse();
 
-    int countUmbrellaBy();
+    // 분실 우산 조회
+    int countUmbrellasByMissedIsTrueAndDeletedIsFalse();
 
-    int countUmbrellasByAndDeletedIsTrue();
+    // 지점 대여 가능 우산 조회
+    int countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(long storeMetaId);
 
-    int countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(long storeMetaId);
+    // 지점 대여중인 우산 조회
+    int countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(long storeMetaId);
 
-    int countUmbrellaByStoreMetaId(long storeId);
+    // 지점 전체 우산 조회
+    int countUmbrellaByStoreMetaIdAndDeletedIsFalse(long storeId);
 
-    int countUmbrellasByStoreMetaIdAndDeletedIsTrue(long storeId);
+    // 지점 분실 우산 조회
+    int countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(long storeId);
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
@@ -1,0 +1,20 @@
+package upbrella.be.umbrella.repository;
+
+public interface UmbrellaRepositoryCustom {
+
+    long countAllUmbrellas();
+
+    long countRentableUmbrellas();
+
+    long countRentedUmbrellas();
+
+    long countMissingUmbrellas();
+
+    long countRentableUmbrellasByStore(long storeMetaId);
+
+    long countRentedUmbrellasByStore(long storeMetaId);
+
+    long countAllUmbrellasByStore(long storeId);
+
+    long countMissingUmbrellasByStore(long storeId);
+}

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
@@ -1,0 +1,90 @@
+package upbrella.be.umbrella.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import static upbrella.be.umbrella.entity.QUmbrella.umbrella;
+
+@RequiredArgsConstructor
+public class UmbrellaRepositoryImpl implements UmbrellaRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public long countAllUmbrellas() {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.deleted.eq(false))
+                .fetchCount();
+    }
+
+    @Override
+    public long countRentableUmbrellas() {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.rentable.eq(true)
+                        .and(umbrella.missed.eq(false))
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countRentedUmbrellas() {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.rentable.eq(false)
+                        .and(umbrella.missed.eq(false))
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countMissingUmbrellas() {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.missed.eq(true)
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countRentableUmbrellasByStore(long storeMetaId) {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.storeMeta.id.eq(storeMetaId)
+                        .and(umbrella.rentable.eq(true))
+                        .and(umbrella.missed.eq(false))
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countRentedUmbrellasByStore(long storeMetaId) {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.storeMeta.id.eq(storeMetaId)
+                        .and(umbrella.rentable.eq(false))
+                        .and(umbrella.missed.eq(false))
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countAllUmbrellasByStore(long storeId) {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.storeMeta.id.eq(storeId)
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+
+    @Override
+    public long countMissingUmbrellasByStore(long storeId) {
+
+        return queryFactory.selectFrom(umbrella)
+                .where(umbrella.storeMeta.id.eq(storeId)
+                        .and(umbrella.missed.eq(true))
+                        .and(umbrella.deleted.eq(false)))
+                .fetchCount();
+    }
+}

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -6,7 +6,8 @@ import org.springframework.stereotype.Service;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.store.service.StoreMetaService;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
@@ -39,33 +40,33 @@ public class UmbrellaService {
     }
 
     @Transactional
-    public Umbrella addUmbrella(UmbrellaRequest umbrellaRequest) {
+    public Umbrella addUmbrella(UmbrellaCreateRequest umbrellaCreateRequest) {
 
-        StoreMeta storeMeta = storeMetaService.findStoreMetaById(umbrellaRequest.getStoreMetaId());
+        StoreMeta storeMeta = storeMetaService.findStoreMetaById(umbrellaCreateRequest.getStoreMetaId());
 
-        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid())) {
+        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaCreateRequest.getUuid())) {
             throw new ExistingUmbrellaUuidException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
         }
 
         return umbrellaRepository.save(
-                Umbrella.ofCreated(umbrellaRequest, storeMeta)
+                Umbrella.ofCreated(umbrellaCreateRequest, storeMeta)
         );
     }
 
     @Transactional
-    public Umbrella modifyUmbrella(long id, UmbrellaRequest umbrellaRequest) {
+    public Umbrella modifyUmbrella(long id, UmbrellaModifyRequest umbrellaModifyRequest) {
 
-        StoreMeta storeMeta = storeMetaService.findStoreMetaById(umbrellaRequest.getStoreMetaId());
+        StoreMeta storeMeta = storeMetaService.findStoreMetaById(umbrellaModifyRequest.getStoreMetaId());
 
         if (!umbrellaRepository.existsByIdAndDeletedIsFalse(id)) {
             throw new NonExistingUmbrellaException("[ERROR] 존재하지 않는 우산 고유번호입니다.");
         }
-        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid())) {
+        if (umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid())) {
             throw new ExistingUmbrellaUuidException("[ERROR] 이미 존재하는 우산 관리 번호입니다.");
         }
 
         return umbrellaRepository.save(
-                Umbrella.ofUpdated(id, umbrellaRequest, storeMeta)
+                Umbrella.ofUpdated(id, umbrellaModifyRequest, storeMeta)
         );
     }
 
@@ -84,7 +85,7 @@ public class UmbrellaService {
 
     public int countAvailableUmbrellaAtStore(long storeMetaId) {
 
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeMetaId);
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeMetaId);
     }
 
     public UmbrellaStatisticsResponse getUmbrellaAllStatistics() {
@@ -114,41 +115,41 @@ public class UmbrellaService {
 
     private int countAvailableUmbrella() {
 
-        return umbrellaRepository.countUmbrellasByRentableIsTrueAndDeletedIsFalse();
+        return umbrellaRepository.countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse();
     }
 
     private int countRentedUmbrella() {
 
-        return umbrellaRepository.countUmbrellasByRentableIsFalseAndDeletedIsFalse();
+        return umbrellaRepository.countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse();
     }
 
     private int countUmbrella() {
 
-        return umbrellaRepository.countUmbrellaBy();
+        return umbrellaRepository.countUmbrellaByDeletedIsFalse();
     }
 
     private int countMissingUmberlla() {
 
-        return umbrellaRepository.countUmbrellasByAndDeletedIsTrue();
+        return umbrellaRepository.countUmbrellasByMissedIsTrueAndDeletedIsFalse();
     }
 
     private int countAvailableUmbrellaByStoreId(long storeId) {
 
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeId);
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId);
     }
 
     private int countRentedUmbrellaByStoreId(long storeId) {
 
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(storeId);
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId);
     }
 
     private int countUmbrellaByStoreId(long storeId) {
 
-        return umbrellaRepository.countUmbrellaByStoreMetaId(storeId);
+        return umbrellaRepository.countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId);
     }
 
     private int countMissingUmberllaByStoreId(long storeId) {
 
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndDeletedIsTrue(storeId);
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId);
     }
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -90,17 +90,17 @@ public class UmbrellaService {
                 .orElseThrow(() -> new NonExistingUmbrellaException("[ERROR] 존재하지 않는 우산 고유번호입니다."));
     }
 
-    public int countAvailableUmbrellaAtStore(long storeMetaId) {
+    public long countAvailableUmbrellaAtStore(long storeMetaId) {
 
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeMetaId);
+        return umbrellaRepository.countRentableUmbrellasByStore(storeMetaId);
     }
 
     public UmbrellaStatisticsResponse getUmbrellaAllStatistics() {
 
-        int totalUmbrella = countUmbrella();
-        int availableUmbrella = countAvailableUmbrella();
-        int rentedUmbrella = countRentedUmbrella();
-        int missingUmbrella = countMissingUmberlla();
+        long totalUmbrella = umbrellaRepository.countAllUmbrellas();
+        long availableUmbrella = umbrellaRepository.countRentableUmbrellas();
+        long rentedUmbrella = umbrellaRepository.countRentedUmbrellas();
+        long missingUmbrella = umbrellaRepository.countMissingUmbrellas();
         long totalRent = rentService.countTotalRent();
 
         return UmbrellaStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella,
@@ -113,53 +113,13 @@ public class UmbrellaService {
             throw new NonExistingStoreMetaException("[ERROR] 존재하지 않는 매장 고유번호입니다.");
         }
 
-        int totalUmbrellaByStoreId = countUmbrellaByStoreId(storeId);
-        int availableUmbrellaByStoreId = countAvailableUmbrellaByStoreId(storeId);
-        int rentedUmbrellaByStoreId = countRentedUmbrellaByStoreId(storeId);
-        int missingUmbrellaByStoreId = countMissingUmberllaByStoreId(storeId);
+        long totalUmbrellaByStoreId = umbrellaRepository.countAllUmbrellasByStore(storeId);
+        long availableUmbrellaByStoreId = umbrellaRepository.countRentableUmbrellasByStore(storeId);
+        long rentedUmbrellaByStoreId = umbrellaRepository.countRentedUmbrellasByStore(storeId);
+        long missingUmbrellaByStoreId = umbrellaRepository.countMissingUmbrellasByStore(storeId);
         long totalRentByStoreId = rentService.countTotalRentByStoreId(storeId);
 
         return UmbrellaStatisticsResponse.fromCounts(totalUmbrellaByStoreId, availableUmbrellaByStoreId,
                 rentedUmbrellaByStoreId, missingUmbrellaByStoreId, totalRentByStoreId);
-    }
-
-    private int countAvailableUmbrella() {
-
-        return umbrellaRepository.countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse();
-    }
-
-    private int countRentedUmbrella() {
-
-        return umbrellaRepository.countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse();
-    }
-
-    private int countUmbrella() {
-
-        return umbrellaRepository.countUmbrellaByDeletedIsFalse();
-    }
-
-    private int countMissingUmberlla() {
-
-        return umbrellaRepository.countUmbrellasByMissedIsTrueAndDeletedIsFalse();
-    }
-
-    private int countAvailableUmbrellaByStoreId(long storeId) {
-
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId);
-    }
-
-    private int countRentedUmbrellaByStoreId(long storeId) {
-
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId);
-    }
-
-    private int countUmbrellaByStoreId(long storeId) {
-
-        return umbrellaRepository.countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId);
-    }
-
-    private int countMissingUmberllaByStoreId(long storeId) {
-
-        return umbrellaRepository.countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId);
     }
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -1,15 +1,16 @@
 package upbrella.be.umbrella.service;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import upbrella.be.rent.service.RentService;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
-import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
 import upbrella.be.umbrella.exception.NonExistingUmbrellaException;
@@ -20,10 +21,16 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Service
-@RequiredArgsConstructor
 public class UmbrellaService {
     private final UmbrellaRepository umbrellaRepository;
     private final StoreMetaService storeMetaService;
+    private final RentService rentService;
+
+    public UmbrellaService(UmbrellaRepository umbrellaRepository, StoreMetaService storeMetaService, @Lazy RentService rentService) {
+        this.umbrellaRepository = umbrellaRepository;
+        this.storeMetaService = storeMetaService;
+        this.rentService = rentService;
+    }
 
     public List<UmbrellaResponse> findAllUmbrellas(Pageable pageable) {
 
@@ -94,8 +101,10 @@ public class UmbrellaService {
         int availableUmbrella = countAvailableUmbrella();
         int rentedUmbrella = countRentedUmbrella();
         int missingUmbrella = countMissingUmberlla();
+        long totalRent = rentService.countTotalRent();
 
-        return UmbrellaStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella, rentedUmbrella, missingUmbrella);
+        return UmbrellaStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella,
+                rentedUmbrella, missingUmbrella, totalRent);
     }
 
     public UmbrellaStatisticsResponse getUmbrellaStatisticsByStoreId(long storeId) {
@@ -108,9 +117,10 @@ public class UmbrellaService {
         int availableUmbrellaByStoreId = countAvailableUmbrellaByStoreId(storeId);
         int rentedUmbrellaByStoreId = countRentedUmbrellaByStoreId(storeId);
         int missingUmbrellaByStoreId = countMissingUmberllaByStoreId(storeId);
+        long totalRentByStoreId = rentService.countTotalRentByStoreId(storeId);
 
         return UmbrellaStatisticsResponse.fromCounts(totalUmbrellaByStoreId, availableUmbrellaByStoreId,
-                rentedUmbrellaByStoreId, missingUmbrellaByStoreId);
+                rentedUmbrellaByStoreId, missingUmbrellaByStoreId, totalRentByStoreId);
     }
 
     private int countAvailableUmbrella() {

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -4,9 +4,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
-import upbrella.be.umbrella.dto.response.UmbrellaAllStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
@@ -86,33 +87,68 @@ public class UmbrellaService {
         return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeMetaId);
     }
 
-    public UmbrellaAllStatisticsResponse getUmbrellaAllStatistics() {
+    public UmbrellaStatisticsResponse getUmbrellaAllStatistics() {
 
         int totalUmbrella = countUmbrella();
         int availableUmbrella = countAvailableUmbrella();
         int rentedUmbrella = countRentedUmbrella();
         int missingUmbrella = countMissingUmberlla();
 
-        return UmbrellaAllStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella, rentedUmbrella, missingUmbrella);
+        return UmbrellaStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella, rentedUmbrella, missingUmbrella);
     }
 
-    public int countAvailableUmbrella() {
+    public UmbrellaStatisticsResponse getUmbrellaStatisticsByStoreId(long storeId) {
+
+        if (!storeMetaService.existByStoreId(storeId)) {
+            throw new NonExistingStoreMetaException("[ERROR] 존재하지 않는 매장 고유번호입니다.");
+        }
+
+        int totalUmbrellaByStoreId = countUmbrellaByStoreId(storeId);
+        int availableUmbrellaByStoreId = countAvailableUmbrellaByStoreId(storeId);
+        int rentedUmbrellaByStoreId = countRentedUmbrellaByStoreId(storeId);
+        int missingUmbrellaByStoreId = countMissingUmberllaByStoreId(storeId);
+
+        return UmbrellaStatisticsResponse.fromCounts(totalUmbrellaByStoreId, availableUmbrellaByStoreId,
+                rentedUmbrellaByStoreId, missingUmbrellaByStoreId);
+    }
+
+    private int countAvailableUmbrella() {
 
         return umbrellaRepository.countUmbrellasByRentableIsTrueAndDeletedIsFalse();
     }
 
-    public int countRentedUmbrella() {
+    private int countRentedUmbrella() {
 
         return umbrellaRepository.countUmbrellasByRentableIsFalseAndDeletedIsFalse();
     }
 
-    public int countUmbrella() {
+    private int countUmbrella() {
 
         return umbrellaRepository.countUmbrellaBy();
     }
 
-    public int countMissingUmberlla() {
+    private int countMissingUmberlla() {
 
         return umbrellaRepository.countUmbrellasByAndDeletedIsTrue();
+    }
+
+    private int countAvailableUmbrellaByStoreId(long storeId) {
+
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeId);
+    }
+
+    private int countRentedUmbrellaByStoreId(long storeId) {
+
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(storeId);
+    }
+
+    private int countUmbrellaByStoreId(long storeId) {
+
+        return umbrellaRepository.countUmbrellaByStoreMetaId(storeId);
+    }
+
+    private int countMissingUmberllaByStoreId(long storeId) {
+
+        return umbrellaRepository.countUmbrellasByStoreMetaIdAndDeletedIsTrue(storeId);
     }
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.response.UmbrellaAllStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
@@ -83,5 +84,35 @@ public class UmbrellaService {
     public int countAvailableUmbrellaAtStore(long storeMetaId) {
 
         return umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeMetaId);
+    }
+
+    public UmbrellaAllStatisticsResponse getUmbrellaAllStatistics() {
+
+        int totalUmbrella = countUmbrella();
+        int availableUmbrella = countAvailableUmbrella();
+        int rentedUmbrella = countRentedUmbrella();
+        int missingUmbrella = countMissingUmberlla();
+
+        return UmbrellaAllStatisticsResponse.fromCounts(totalUmbrella, availableUmbrella, rentedUmbrella, missingUmbrella);
+    }
+
+    public int countAvailableUmbrella() {
+
+        return umbrellaRepository.countUmbrellasByRentableIsTrueAndDeletedIsFalse();
+    }
+
+    public int countRentedUmbrella() {
+
+        return umbrellaRepository.countUmbrellasByRentableIsFalseAndDeletedIsFalse();
+    }
+
+    public int countUmbrella() {
+
+        return umbrellaRepository.countUmbrellaBy();
+    }
+
+    public int countMissingUmberlla() {
+
+        return umbrellaRepository.countUmbrellasByAndDeletedIsTrue();
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,3 @@
 spring:
   profiles:
-    active: prod
+    active: dev

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -6,7 +6,8 @@ import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import net.jqwik.api.Arbitraries;
 import upbrella.be.store.entity.StoreMeta;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
@@ -101,10 +102,16 @@ public class FixtureBuilderFactory {
                 .set("uuid", buildLong(100));
     }
 
+    public static ArbitraryBuilder<UmbrellaCreateRequest> builderUmbrellaCreateRequest() {
 
-    public static ArbitraryBuilder<UmbrellaRequest> builderUmbrellaRequest() {
+        return fixtureMonkey.giveMeBuilder(UmbrellaCreateRequest.class)
+                .set("storeMetaId", buildLong(100))
+                .set("uuid", buildLong(100));
+    }
 
-        return fixtureMonkey.giveMeBuilder(UmbrellaRequest.class)
+    public static ArbitraryBuilder<UmbrellaModifyRequest> builderUmbrellaModifyRequest() {
+
+        return fixtureMonkey.giveMeBuilder(UmbrellaModifyRequest.class)
                 .set("storeMetaId", buildLong(100))
                 .set("uuid", buildLong(100));
     }

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -5,9 +5,9 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import net.jqwik.api.Arbitraries;
-import net.jqwik.engine.providers.ArbitraryArbitraryProvider;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
@@ -26,9 +26,10 @@ public class FixtureBuilderFactory {
     private static String[] cafeList = {"투썸", "스타벅스", "이디야", "커피빈", "엔젤리너스", "할리스", "탐앤탐스", "커피마마", "커피에반하다", "커피나무"};
     private static String[] bankList = {"농협", "신한", "우리", "카카오뱅크", "하나", "기업", "케이뱅크", "SC제일", "경남", "광주", "대구", "부산", "전북", "제주", "수협", "새마을", "신협", "우체국", "전북", "제주", "수협", "새마을", "신협", "우체국"};
     private static String[] addressList = {"신촌", "홍대", "강남", "강북", "강서", "강동", "서초", "서대문", "마포", "종로", "용산", "성동", "성북", "중랑", "중구", "동대문", "동작", "관악"};
+
     private static String pickRandomString(String[] names) {
 
-        return names[buildInteger() % names.length];
+        return names[buildInteger(10000) % names.length];
     }
 
     private static String pickPhoneNumberString() {
@@ -36,9 +37,9 @@ public class FixtureBuilderFactory {
         StringBuilder sb = new StringBuilder();
         sb.append("010")
                 .append("-")
-                .append(Arbitraries.integers().between(1000,9999).sample())
+                .append(Arbitraries.integers().between(1000, 9999).sample())
                 .append("-")
-                .append(Arbitraries.integers().between(1000,9999).sample());
+                .append(Arbitraries.integers().between(1000, 9999).sample());
 
         return sb.toString();
     }
@@ -46,67 +47,73 @@ public class FixtureBuilderFactory {
     private static String pickAccountNumberString() {
 
         StringBuilder sb = new StringBuilder();
-        sb.append(Arbitraries.integers().between(100,999).sample())
+        sb.append(Arbitraries.integers().between(100, 999).sample())
                 .append("-")
-                .append(Arbitraries.integers().between(100,999).sample())
+                .append(Arbitraries.integers().between(100, 999).sample())
                 .append("-")
-                .append(Arbitraries.integers().between(100000,999999).sample());
+                .append(Arbitraries.integers().between(100000, 999999).sample());
 
         return sb.toString();
     }
 
-    public static int buildInteger() {
+    public static int buildInteger(int bound) {
 
-        return Randoms.nextInt(10000);
+        return Randoms.nextInt(bound);
     }
 
-    public static long buildLong() {
+    public static long buildLong(int bound) {
 
-        return Randoms.nextInt(10000);
+        return Randoms.nextInt(bound);
+    }
+
+    public static double buildDouble() {
+
+        return Arbitraries.doubles().between(1, 100).sample();
     }
 
     public static ArbitraryBuilder<StoreMeta> builderStoreMeta() {
 
         return fixtureMonkey.giveMeBuilder(StoreMeta.class)
                 .set("deleted", false)
-                .set("id", buildLong())
+                .set("id", buildLong(100))
                 .set("name", pickRandomString(cafeList))
                 .set("address", pickRandomString(addressList))
                 .set("category", pickRandomString(addressList))
-                .set("password", String.valueOf(buildInteger()))
-                .set("latitude", Arbitraries.doubles().between(1, 100).sample())
-                .set("longitude", Arbitraries.doubles().between(1, 100).sample());
+                .set("password", String.valueOf(buildInteger(10000)))
+                .set("latitude", buildDouble())
+                .set("longitude", buildDouble());
     }
 
     public static ArbitraryBuilder<Umbrella> builderUmbrella() {
 
         return fixtureMonkey.giveMeBuilder(Umbrella.class)
-                .set("id", buildLong())
-                .set("uuid", buildLong())
+                .set("id", buildLong(10000))
+                .set("uuid", buildLong(1000))
                 .set("storeMeta", builderStoreMeta().sample())
                 .set("deleted", false);
     }
+
     public static ArbitraryBuilder<UmbrellaResponse> builderUmbrellaResponses() {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
-                .set("id", buildLong())
-                .set("storeMetaId", buildLong())
-                .set("uuid", buildLong());
+                .set("id", buildLong(10000))
+                .set("storeMetaId", buildLong(100))
+                .set("uuid", buildLong(100));
     }
 
 
     public static ArbitraryBuilder<UmbrellaRequest> builderUmbrellaRequest() {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaRequest.class)
-                .set("storeMetaId", buildLong())
-                .set("uuid", buildLong());
+                .set("storeMetaId", buildLong(100))
+                .set("uuid", buildLong(100));
     }
 
     public static ArbitraryBuilder<User> builderUser() {
 
         return fixtureMonkey.giveMeBuilder(User.class)
-                .set("id", buildLong())
-                .set("socialId", buildLong())
+                .set("id", buildLong(100))
+                .set("socialId", buildLong(100000000))
                 .set("name", pickRandomString(nameList))
                 .set("phoneNumber", pickPhoneNumberString())
                 .set("bank", pickRandomString(bankList))
@@ -117,7 +124,7 @@ public class FixtureBuilderFactory {
     public static ArbitraryBuilder<SingleHistoryResponse> builderSingleHistoryResponse() {
 
         return fixtureMonkey.giveMeBuilder(SingleHistoryResponse.class)
-                .set("umbrellaUuid", buildLong())
+                .set("umbrellaUuid", buildLong(1000))
                 .set("rentedStore", pickRandomString(cafeList));
     }
 
@@ -132,8 +139,23 @@ public class FixtureBuilderFactory {
 
     public static ArbitraryBuilder<UpdateBankAccountRequest> builderBankAccount() {
 
-            return fixtureMonkey.giveMeBuilder(UpdateBankAccountRequest.class)
-                    .set("bank", pickRandomString(bankList))
-                    .set("accountNumber", pickAccountNumberString());
+        return fixtureMonkey.giveMeBuilder(UpdateBankAccountRequest.class)
+                .set("bank", pickRandomString(bankList))
+                .set("accountNumber", pickAccountNumberString());
+    }
+
+    public static ArbitraryBuilder<UmbrellaStatisticsResponse> builderUmbrellaStatisticsResponse() {
+
+        int missingUmbrellaCount = buildInteger(100);
+        int rentableUmbrellaCount = buildInteger(100);
+        int rentedUmbrellaCount = buildInteger(100);
+        int totalUmbrellaCount = missingUmbrellaCount + rentedUmbrellaCount + rentedUmbrellaCount;
+        double missingRate = (double)100*missingUmbrellaCount / totalUmbrellaCount;
+        return fixtureMonkey.giveMeBuilder(UmbrellaStatisticsResponse.class)
+                .set("totalUmbrellaCount", totalUmbrellaCount)
+                .set("rentableUmbrellaCount", buildInteger(100))
+                .set("rentedUmbrellaCount", buildInteger(100))
+                .set("missingUmbrellaCount", missingUmbrellaCount)
+                .set("missingRate", missingRate);
     }
 }

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -156,13 +156,14 @@ public class FixtureBuilderFactory {
         int missingUmbrellaCount = buildInteger(100);
         int rentableUmbrellaCount = buildInteger(100);
         int rentedUmbrellaCount = buildInteger(100);
-        int totalUmbrellaCount = missingUmbrellaCount + rentedUmbrellaCount + rentedUmbrellaCount;
+        int totalUmbrellaCount = missingUmbrellaCount + rentableUmbrellaCount + rentedUmbrellaCount;
         double missingRate = (double)100*missingUmbrellaCount / totalUmbrellaCount;
         return fixtureMonkey.giveMeBuilder(UmbrellaStatisticsResponse.class)
                 .set("totalUmbrellaCount", totalUmbrellaCount)
                 .set("rentableUmbrellaCount", buildInteger(100))
                 .set("rentedUmbrellaCount", buildInteger(100))
                 .set("missingUmbrellaCount", missingUmbrellaCount)
+                .set("totalRentCount", buildLong(1000))
                 .set("missingRate", missingRate);
     }
 }

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -4,7 +4,8 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import upbrella.be.rent.entity.History;
 import upbrella.be.store.entity.StoreMeta;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
@@ -30,22 +31,22 @@ public class FixtureFactory {
                 .sample();
     }
 
-    public static Umbrella buildUmbrellaWithUmbrellaRequestAndStoreMeta(UmbrellaRequest umbrellaRequest, StoreMeta storeMeta) {
+    public static Umbrella buildUmbrellaWithUmbrellaRequestAndStoreMeta(UmbrellaCreateRequest umbrellaCreateRequest, StoreMeta storeMeta) {
 
         return builderUmbrella()
                 .set("storeMeta", storeMeta)
-                .set("uuid", umbrellaRequest.getUuid())
-                .set("rentable", umbrellaRequest.isRentable())
+                .set("uuid", umbrellaCreateRequest.getUuid())
+                .set("rentable", umbrellaCreateRequest.isRentable())
                 .sample();
     }
 
-    public static Umbrella buildUmbrellaWithIdAndUmbrellaRequestAndStoreMeta(long id, UmbrellaRequest umbrellaRequest, StoreMeta storeMeta) {
+    public static Umbrella buildUmbrellaWithIdAndUmbrellaRequestAndStoreMeta(long id, UmbrellaModifyRequest umbrellaModifyRequest, StoreMeta storeMeta) {
 
         return builderUmbrella()
                 .set("id", id)
                 .set("storeMeta", storeMeta)
-                .set("uuid", umbrellaRequest.getUuid())
-                .set("rentable", umbrellaRequest.isRentable())
+                .set("uuid", umbrellaModifyRequest.getUuid())
+                .set("rentable", umbrellaModifyRequest.isRentable())
                 .sample();
     }
 

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -95,7 +95,7 @@ public class StoreDetailServiceTest {
                     .willReturn(Optional.of(storeDetail));
 
             given(umbrellaService.countAvailableUmbrellaAtStore(3L))
-                    .willReturn(10);
+                    .willReturn(10L);
 
             //when
             StoreFindByIdResponse storeFindByIdResponse = storeDetailService.findStoreDetailByStoreMetaId(3L);

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -14,7 +14,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.docs.utils.RestDocsSupport;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
@@ -152,15 +153,15 @@ public class UmbrellaControllerTest extends RestDocsSupport {
         void success() throws Exception {
 
             // given
-            UmbrellaRequest umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest()
+            UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
                     .sample();
-            given(umbrellaService.addUmbrella(refEq(umbrellaRequest)))
+            given(umbrellaService.addUmbrella(refEq(umbrellaCreateRequest)))
                     .willReturn(FixtureBuilderFactory.builderUmbrella().sample());
 
             // when & then
             mockMvc.perform(
                             post("/umbrellas")
-                                    .content(objectMapper.writeValueAsString(umbrellaRequest))
+                                    .content(objectMapper.writeValueAsString(umbrellaCreateRequest))
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON)
                     ).andDo(print())
@@ -182,18 +183,18 @@ public class UmbrellaControllerTest extends RestDocsSupport {
         void existingUmbrellaUuid() throws Exception {
 
             // given
-            UmbrellaRequest umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest()
+            UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
                     .sample();
 
             mockMvc = RestDocsSupport.setControllerAdvice(initController(), new UmbrellaExceptionHandler());
 
-            given(umbrellaService.addUmbrella(refEq(umbrellaRequest)))
+            given(umbrellaService.addUmbrella(refEq(umbrellaCreateRequest)))
                     .willThrow(new ExistingUmbrellaUuidException("[ERROR] 이미 존재하는 우산 관리번호입니다."));
 
             // when & then
             mockMvc.perform(
                             post("/umbrellas")
-                                    .content(objectMapper.writeValueAsString(umbrellaRequest))
+                                    .content(objectMapper.writeValueAsString(umbrellaCreateRequest))
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
@@ -213,16 +214,16 @@ public class UmbrellaControllerTest extends RestDocsSupport {
 
             // given
             long id = FixtureBuilderFactory.buildLong(1000);
-            UmbrellaRequest umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest()
+            UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                     .sample();
 
-            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaRequest)))
+            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaModifyRequest)))
                     .willReturn(FixtureBuilderFactory.builderUmbrella().sample());
 
             // when & then
             mockMvc.perform(
                             patch("/umbrellas/{umbrellaId}", id)
-                                    .content(objectMapper.writeValueAsString(umbrellaRequest))
+                                    .content(objectMapper.writeValueAsString(umbrellaModifyRequest))
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON)
                     ).andDo(print())
@@ -236,7 +237,10 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                     fieldWithPath("storeMetaId").type(JsonFieldType.NUMBER)
                                             .description("지점 고유번호"),
                                     fieldWithPath("rentable").type(JsonFieldType.BOOLEAN)
-                                            .description("대여 가능 여부")),
+                                            .description("대여 가능 여부"),
+                                    fieldWithPath("missed").type(JsonFieldType.BOOLEAN)
+                                            .description("분실 여부"))
+                            ,
                             pathParameters(
                                     parameterWithName("umbrellaId").description("우산 고유번호")
                             )));
@@ -248,18 +252,18 @@ public class UmbrellaControllerTest extends RestDocsSupport {
 
             // given
             long id = FixtureBuilderFactory.buildLong(1000);
-            UmbrellaRequest umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest()
+            UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                     .sample();
 
             mockMvc = RestDocsSupport.setControllerAdvice(initController(), new UmbrellaExceptionHandler());
 
-            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaRequest)))
+            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaModifyRequest)))
                     .willThrow(new ExistingUmbrellaUuidException("[ERROR] 이미 존재하는 우산 관리번호입니다."));
 
             // when & then
             mockMvc.perform(
                             patch("/umbrellas/{umbrellaId}", id)
-                                    .content(objectMapper.writeValueAsString(umbrellaRequest))
+                                    .content(objectMapper.writeValueAsString(umbrellaModifyRequest))
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())
@@ -274,18 +278,18 @@ public class UmbrellaControllerTest extends RestDocsSupport {
 
             // given
             long id = FixtureBuilderFactory.buildLong(1000);
-            UmbrellaRequest umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest()
+            UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                     .sample();
 
             mockMvc = RestDocsSupport.setControllerAdvice(initController(), new UmbrellaExceptionHandler());
 
-            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaRequest)))
+            given(umbrellaService.modifyUmbrella(eq(id), refEq(umbrellaModifyRequest)))
                     .willThrow(new NonExistingUmbrellaException("[ERROR] 존재하지 않는 우산 관리번호입니다."));
 
             // when & then
             mockMvc.perform(
                             patch("/umbrellas/{umbrellaId}", id)
-                                    .content(objectMapper.writeValueAsString(umbrellaRequest))
+                                    .content(objectMapper.writeValueAsString(umbrellaModifyRequest))
                                     .contentType(MediaType.APPLICATION_JSON)
                                     .accept(MediaType.APPLICATION_JSON))
                     .andExpect(status().isBadRequest())

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -368,6 +368,8 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                         getDocumentResponse(),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("totalRentCount").type(JsonFieldType.NUMBER)
+                                        .description("전체 대여 건수"),
                                 fieldWithPath("totalUmbrellaCount").type(JsonFieldType.NUMBER)
                                         .description("전체 우산 개수"),
                                 fieldWithPath("rentableUmbrellaCount").type(JsonFieldType.NUMBER)
@@ -404,6 +406,8 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                         getDocumentResponse(),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("totalRentCount").type(JsonFieldType.NUMBER)
+                                        .description("지점 전체 대여 건수"),
                                 fieldWithPath("totalUmbrellaCount").type(JsonFieldType.NUMBER)
                                         .description("지점 전체 우산 개수"),
                                 fieldWithPath("rentableUmbrellaCount").type(JsonFieldType.NUMBER)

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -15,7 +15,8 @@ import upbrella.be.config.FixtureFactory;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.store.service.StoreMetaService;
-import upbrella.be.umbrella.dto.request.UmbrellaRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.entity.Umbrella;
@@ -173,17 +174,17 @@ class UmbrellaServiceTest {
     @Nested
     @DisplayName("우산의 고유번호, 협력 지점 고유번호, 대여 여부를 입력받아")
     class addUmbrellaTest {
-        private UmbrellaRequest umbrellaRequest;
+        private UmbrellaCreateRequest umbrellaCreateRequest;
         private StoreMeta foundStoreMeta;
         private Umbrella umbrella;
 
         @BeforeEach
         void setUp() {
-            umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest().sample();
+            umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest().sample();
 
-            foundStoreMeta = FixtureFactory.buildStoreMetaWithId(umbrellaRequest.getStoreMetaId());
+            foundStoreMeta = FixtureFactory.buildStoreMetaWithId(umbrellaCreateRequest.getStoreMetaId());
 
-            umbrella = FixtureFactory.buildUmbrellaWithUmbrellaRequestAndStoreMeta(umbrellaRequest, foundStoreMeta);
+            umbrella = FixtureFactory.buildUmbrellaWithUmbrellaRequestAndStoreMeta(umbrellaCreateRequest, foundStoreMeta);
         }
 
         @Test
@@ -193,13 +194,13 @@ class UmbrellaServiceTest {
             // given
             given(storeMetaService.findStoreMetaById(foundStoreMeta.getId()))
                     .willReturn(foundStoreMeta);
-            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()))
+            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaCreateRequest.getUuid()))
                     .willReturn(false);
             given(umbrellaRepository.save(any(Umbrella.class)))
                     .willReturn(umbrella);
 
             // when
-            Umbrella addedUmbrella = umbrellaService.addUmbrella(umbrellaRequest);
+            Umbrella addedUmbrella = umbrellaService.addUmbrella(umbrellaCreateRequest);
 
             // then
             assertAll(
@@ -207,7 +208,7 @@ class UmbrellaServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(umbrella),
                     () -> then(umbrellaRepository).should(times(1))
-                            .existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()),
+                            .existsByUuidAndDeletedIsFalse(umbrellaCreateRequest.getUuid()),
                     () -> then(storeMetaService).should(times(1))
                             .findStoreMetaById(foundStoreMeta.getId()),
                     () -> then(umbrellaRepository).should(times(1))
@@ -226,7 +227,7 @@ class UmbrellaServiceTest {
                     .willReturn(true);
 
             // when
-            assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
+            assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaCreateRequest))
                     .isInstanceOf(ExistingUmbrellaUuidException.class);
 
             // then
@@ -234,7 +235,7 @@ class UmbrellaServiceTest {
                     () -> then(storeMetaService).should(times(1))
                             .findStoreMetaById(foundStoreMeta.getId()),
                     () -> then(umbrellaRepository).should(times(1))
-                            .existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()),
+                            .existsByUuidAndDeletedIsFalse(umbrellaCreateRequest.getUuid()),
                     () -> then(umbrellaRepository).should(never())
                             .save(any(Umbrella.class))
             );
@@ -250,7 +251,7 @@ class UmbrellaServiceTest {
 
             // when & then
             assertAll(
-                    () -> assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaRequest))
+                    () -> assertThatThrownBy(() -> umbrellaService.addUmbrella(umbrellaCreateRequest))
                             .isInstanceOf(NonExistingStoreMetaException.class),
                     () -> then(storeMetaService).should(times(1))
                             .findStoreMetaById(foundStoreMeta.getId()),
@@ -262,7 +263,7 @@ class UmbrellaServiceTest {
     @Nested
     @DisplayName("우산의 고유번호, 협력 지점 고유번호, 대여 여부를 입력받아")
     class modifyUmbrellaTest {
-        private UmbrellaRequest umbrellaRequest;
+        private UmbrellaModifyRequest umbrellaModifyRequest;
         private StoreMeta foundStoreMeta;
         private Umbrella umbrella;
         private long id;
@@ -272,11 +273,11 @@ class UmbrellaServiceTest {
 
             id = FixtureBuilderFactory.buildLong(1000);
 
-            umbrellaRequest = FixtureBuilderFactory.builderUmbrellaRequest().sample();
+            umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest().sample();
 
-            foundStoreMeta = FixtureFactory.buildStoreMetaWithId(umbrellaRequest.getStoreMetaId());
+            foundStoreMeta = FixtureFactory.buildStoreMetaWithId(umbrellaModifyRequest.getStoreMetaId());
 
-            umbrella = FixtureFactory.buildUmbrellaWithIdAndUmbrellaRequestAndStoreMeta(id, umbrellaRequest, foundStoreMeta);
+            umbrella = FixtureFactory.buildUmbrellaWithIdAndUmbrellaRequestAndStoreMeta(id, umbrellaModifyRequest, foundStoreMeta);
         }
 
         @Test
@@ -288,13 +289,13 @@ class UmbrellaServiceTest {
                     .willReturn(foundStoreMeta);
             given(umbrellaRepository.existsByIdAndDeletedIsFalse(id))
                     .willReturn(true);
-            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()))
+            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid()))
                     .willReturn(false);
             given(umbrellaRepository.save(any(Umbrella.class)))
                     .willReturn(umbrella);
 
             // when
-            Umbrella modifiedUmbrella = umbrellaService.modifyUmbrella(umbrella.getId(), umbrellaRequest);
+            Umbrella modifiedUmbrella = umbrellaService.modifyUmbrella(umbrella.getId(), umbrellaModifyRequest);
 
             // then
             assertAll(
@@ -302,7 +303,7 @@ class UmbrellaServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(umbrella),
                     () -> then(umbrellaRepository).should(times(1))
-                            .existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()),
+                            .existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid()),
                     () -> then(umbrellaRepository).should(times(1))
                             .existsByIdAndDeletedIsFalse(id),
                     () -> then(storeMetaService).should(times(1))
@@ -325,10 +326,10 @@ class UmbrellaServiceTest {
             // when & then
             assertAll(
                     () -> assertThatThrownBy(() ->
-                            umbrellaService.modifyUmbrella(id, umbrellaRequest))
+                            umbrellaService.modifyUmbrella(id, umbrellaModifyRequest))
                             .isInstanceOf(NonExistingUmbrellaException.class),
                     () -> then(umbrellaRepository).should(never())
-                            .existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()),
+                            .existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid()),
                     () -> then(umbrellaRepository).should(times(1))
                             .existsByIdAndDeletedIsFalse(id),
                     () -> then(storeMetaService).should(times(1))
@@ -347,16 +348,16 @@ class UmbrellaServiceTest {
                     .willReturn(foundStoreMeta);
             given(umbrellaRepository.existsByIdAndDeletedIsFalse(id))
                     .willReturn(true);
-            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()))
+            given(umbrellaRepository.existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid()))
                     .willReturn(true);
 
             // when & then
             assertAll(
                     () -> assertThatThrownBy(() ->
-                            umbrellaService.modifyUmbrella(id, umbrellaRequest))
+                            umbrellaService.modifyUmbrella(id, umbrellaModifyRequest))
                             .isInstanceOf(ExistingUmbrellaUuidException.class),
                     () -> then(umbrellaRepository).should(times(1))
-                            .existsByUuidAndDeletedIsFalse(umbrellaRequest.getUuid()),
+                            .existsByUuidAndDeletedIsFalse(umbrellaModifyRequest.getUuid()),
                     () -> then(umbrellaRepository).should(times(1))
                             .existsByIdAndDeletedIsFalse(id),
                     () -> then(storeMetaService).should(times(1))
@@ -377,7 +378,7 @@ class UmbrellaServiceTest {
             // when & then
             assertAll(
                     () -> assertThatThrownBy(() ->
-                            umbrellaService.modifyUmbrella(id, umbrellaRequest))
+                            umbrellaService.modifyUmbrella(id, umbrellaModifyRequest))
                             .isInstanceOf(NonExistingStoreMetaException.class),
                     () -> then(storeMetaService).should(times(1))
                             .findStoreMetaById(foundStoreMeta.getId()),
@@ -449,7 +450,7 @@ class UmbrellaServiceTest {
             // given
             long id = FixtureBuilderFactory.buildLong(1000);
             int availableCount = FixtureBuilderFactory.buildInteger(100);
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(id))
+            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(id))
                     .willReturn(availableCount);
 
             // when
@@ -460,7 +461,7 @@ class UmbrellaServiceTest {
                     () -> assertThat(count)
                             .isEqualTo(availableCount),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(id)
+                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(id)
             );
         }
     }
@@ -478,13 +479,13 @@ class UmbrellaServiceTest {
         int rentedCount = expected.getRentedUmbrellaCount();
         int missingCount = expected.getMissingUmbrellaCount();
 
-        given(umbrellaRepository.countUmbrellaBy())
+        given(umbrellaRepository.countUmbrellaByDeletedIsFalse())
                 .willReturn(totalCount);
-        given(umbrellaRepository.countUmbrellasByRentableIsTrueAndDeletedIsFalse())
+        given(umbrellaRepository.countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse())
                 .willReturn(rentableCount);
-        given(umbrellaRepository.countUmbrellasByRentableIsFalseAndDeletedIsFalse())
+        given(umbrellaRepository.countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse())
                 .willReturn(rentedCount);
-        given(umbrellaRepository.countUmbrellasByAndDeletedIsTrue())
+        given(umbrellaRepository.countUmbrellasByMissedIsTrueAndDeletedIsFalse())
                 .willReturn(missingCount);
 
         // when
@@ -496,13 +497,13 @@ class UmbrellaServiceTest {
                         .usingRecursiveComparison()
                         .isEqualTo(expected),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellaBy(),
+                        .countUmbrellaByDeletedIsFalse(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByRentableIsTrueAndDeletedIsFalse(),
+                        .countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByRentableIsFalseAndDeletedIsFalse(),
+                        .countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByAndDeletedIsTrue());
+                        .countUmbrellasByMissedIsTrueAndDeletedIsFalse());
     }
 
     @Nested
@@ -525,13 +526,13 @@ class UmbrellaServiceTest {
 
             given(storeMetaService.existByStoreId(storeId))
                     .willReturn(true);
-            given(umbrellaRepository.countUmbrellaByStoreMetaId(storeId))
+            given(umbrellaRepository.countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId))
                     .willReturn(totalCount);
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId))
                     .willReturn(rentableCount);
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId))
                     .willReturn(rentedCount);
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndDeletedIsTrue(storeId))
+            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId))
                     .willReturn(missingCount);
 
             // when
@@ -543,13 +544,13 @@ class UmbrellaServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(expected),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellaByStoreMetaId(storeId),
+                            .countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndDeletedIsFalse(storeId),
+                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsFalseAndDeletedIsFalse(storeId),
+                            .countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndDeletedIsTrue(storeId),
+                            .countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId),
                     () -> then(storeMetaService).should(times(1))
                             .existByStoreId(storeId));
         }

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -452,19 +452,19 @@ class UmbrellaServiceTest {
 
             // given
             long id = FixtureBuilderFactory.buildLong(1000);
-            int availableCount = FixtureBuilderFactory.buildInteger(100);
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(id))
+            long availableCount = FixtureBuilderFactory.buildInteger(100);
+            given(umbrellaRepository.countRentableUmbrellasByStore(id))
                     .willReturn(availableCount);
 
             // when
-            int count = umbrellaService.countAvailableUmbrellaAtStore(id);
+            long count = umbrellaService.countAvailableUmbrellaAtStore(id);
 
             // then
             assertAll(
                     () -> assertThat(count)
                             .isEqualTo(availableCount),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(id)
+                            .countRentableUmbrellasByStore(id)
             );
         }
     }
@@ -477,13 +477,13 @@ class UmbrellaServiceTest {
         UmbrellaStatisticsResponse expected = FixtureBuilderFactory.builderUmbrellaStatisticsResponse()
                 .sample();
 
-        given(umbrellaRepository.countUmbrellaByDeletedIsFalse())
+        given(umbrellaRepository.countAllUmbrellas())
                 .willReturn(expected.getTotalUmbrellaCount());
-        given(umbrellaRepository.countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse())
+        given(umbrellaRepository.countRentableUmbrellas())
                 .willReturn(expected.getRentableUmbrellaCount());
-        given(umbrellaRepository.countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse())
+        given(umbrellaRepository.countRentedUmbrellas())
                 .willReturn(expected.getRentedUmbrellaCount());
-        given(umbrellaRepository.countUmbrellasByMissedIsTrueAndDeletedIsFalse())
+        given(umbrellaRepository.countMissingUmbrellas())
                 .willReturn(expected.getMissingUmbrellaCount());
         given(rentService.countTotalRent())
                 .willReturn(expected.getTotalRentCount());
@@ -497,13 +497,13 @@ class UmbrellaServiceTest {
                         .usingRecursiveComparison()
                         .isEqualTo(expected),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellaByDeletedIsFalse(),
+                        .countAllUmbrellas(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(),
+                        .countRentableUmbrellas(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(),
+                        .countRentedUmbrellas(),
                 () -> then(umbrellaRepository).should(times(1))
-                        .countUmbrellasByMissedIsTrueAndDeletedIsFalse(),
+                        .countMissingUmbrellas(),
                 () -> then(rentService).should(times(1))
                         .countTotalRent());
     }
@@ -525,13 +525,13 @@ class UmbrellaServiceTest {
 
             given(storeMetaService.existByStoreId(storeId))
                     .willReturn(true);
-            given(umbrellaRepository.countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countAllUmbrellasByStore(storeId))
                     .willReturn(expected.getTotalUmbrellaCount());
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countRentableUmbrellasByStore(storeId))
                     .willReturn(expected.getRentableUmbrellaCount());
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countRentedUmbrellasByStore(storeId))
                     .willReturn(expected.getRentedUmbrellaCount());
-            given(umbrellaRepository.countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId))
+            given(umbrellaRepository.countMissingUmbrellasByStore(storeId))
                     .willReturn(expected.getMissingUmbrellaCount());
             given(rentService.countTotalRentByStoreId(storeId))
                     .willReturn(expected.getTotalRentCount());
@@ -545,13 +545,13 @@ class UmbrellaServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(expected),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellaByStoreMetaIdAndDeletedIsFalse(storeId),
+                            .countAllUmbrellasByStore(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsTrueAndMissedIsFalseAndDeletedIsFalse(storeId),
+                            .countRentableUmbrellasByStore(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndRentableIsFalseAndMissedIsFalseAndDeletedIsFalse(storeId),
+                            .countRentedUmbrellasByStore(storeId),
                     () -> then(umbrellaRepository).should(times(1))
-                            .countUmbrellasByStoreMetaIdAndMissedIsTrueAndDeletedIsFalse(storeId),
+                            .countMissingUmbrellasByStore(storeId),
                     () -> then(storeMetaService).should(times(1))
                             .existByStoreId(storeId),
                     () -> then(rentService).should(times(1))

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -127,7 +127,7 @@ public class UserControllerTest extends RestDocsSupport {
             code = "1kdfjq0243f";
             oauthToken = FixtureFactory.buildOauthToken();
             kakaoLoginResponse = FixtureFactory.buildKakaoLoginResponse();
-            userId = FixtureBuilderFactory.buildLong();
+            userId = FixtureBuilderFactory.buildLong(1000);
         }
 
         @Test
@@ -224,7 +224,7 @@ public class UserControllerTest extends RestDocsSupport {
             joinRequest = FixtureBuilderFactory.builderJoinRequest().sample();
             oauthToken = FixtureFactory.buildOauthToken();
             kakaoLoginResponse = FixtureFactory.buildKakaoLoginResponse();
-            userId = FixtureBuilderFactory.buildLong();
+            userId = FixtureBuilderFactory.buildLong(1000);
             mockHttpSession = new MockHttpSession();
         }
 

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -51,7 +51,7 @@ class UserServiceTest {
         void setUp() {
 
             user = FixtureBuilderFactory.builderUser().sample();
-            notExistingSocialId = FixtureBuilderFactory.buildInteger();
+            notExistingSocialId = FixtureBuilderFactory.buildInteger(10000000);
         }
 
         @Test
@@ -101,8 +101,8 @@ class UserServiceTest {
         void setUp() {
 
             user = FixtureBuilderFactory.builderUser().sample();
-            existingSocialId = FixtureBuilderFactory.buildLong();
-            notExistingSocialId = FixtureBuilderFactory.buildLong();
+            existingSocialId = FixtureBuilderFactory.buildLong(100000000);
+            notExistingSocialId = FixtureBuilderFactory.buildLong(100000000);
             joinRequest = FixtureFactory.buildJoinRequestWithUser(user);
         }
 


### PR DESCRIPTION
## 🟢 구현내용

- #141
- #142 

## 🧩 고민과 해결과정

지점 우산의 통계기능을 구현하기 위해 필요한 기능들을 전체 우산에 그대로 적용해도 될것같아 아래와 같이 기능 구현했습니다.
전체 : /umbrellas/statistics
지점 조회 : /umbrellas/statistics/{storeId}

<img width="1141" alt="image" src="https://github.com/UPbrella/UPbrella_back/assets/112251635/b84bc29a-da8c-4007-9a2d-6ad8d080720e">

고민되는 점은 삭제를 분실과 동일한 기능으로 사용할지입니다. 일단은 삭제 == 분실로 간주한다고 생각해서
우산의 총 개수 = 대여 중 + 대여 완료 + 삭제된 우산(분실 우산)
위 로직이 성립하게 구현했고, 테스트 코드도 업데이트했습니다. 