### PR TITLE
[feat] 환급 확인, 지불 확인 기능 구현 및 테스트 작성

### DIFF
--- a/src/docs/asciidoc/api/rent/rent.adoc
+++ b/src/docs/asciidoc/api/rent/rent.adoc
@@ -51,3 +51,14 @@ include::{snippets}/show-all-improvements-doc/http-request.adoc[]
 include::{snippets}/show-all-improvements-doc/http-response.adoc[]
 include::{snippets}/show-all-improvements-doc/response-fields-data.adoc[]
 
+=== 대여 환급 확인
+==== HTTP Request
+
+include::{snippets}/refund-rent-doc/http-request.adoc[]
+include::{snippets}/refund-rent-doc/path-parameters.adoc[]
+
+=== 대여 지불 확인
+==== HTTP Request
+
+include::{snippets}/check-payment-doc/http-request.adoc[]
+include::{snippets}/check-payment-doc/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -6,7 +6,10 @@ import org.springframework.web.bind.annotation.*;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;
-import upbrella.be.rent.dto.response.*;
+import upbrella.be.rent.dto.response.ConditionReportPageResponse;
+import upbrella.be.rent.dto.response.ImprovementReportPageResponse;
+import upbrella.be.rent.dto.response.RentFormResponse;
+import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
 import upbrella.be.rent.service.ConditionReportService;
 import upbrella.be.rent.service.ImprovementReportService;
 import upbrella.be.rent.service.RentService;
@@ -138,6 +141,36 @@ public class RentController {
                         200,
                         "개선 요청 내역 조회 성공",
                         improvementReports
+                ));
+    }
+
+    @PatchMapping("/histories/refund/{historyId}")
+    public ResponseEntity<CustomResponse> refundRent(@PathVariable long historyId, HttpSession httpSession) {
+
+        long loginedUserId = (long) httpSession.getAttribute("userId");
+
+        rentService.checkRefund(historyId, loginedUserId);
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse(
+                        "success",
+                        200,
+                        "환급 확인 성공"
+                ));
+    }
+
+    @PatchMapping("/histories/payment/{historyId}")
+    public ResponseEntity<CustomResponse> checkPayment(@PathVariable long historyId, HttpSession httpSession) {
+
+        long loginedUserId = (long) httpSession.getAttribute("userId");
+
+        rentService.checkPayment(historyId, loginedUserId);
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse(
+                        "success",
+                        200,
+                        "입금 확인 성공"
                 ));
     }
 }

--- a/src/main/java/upbrella/be/rent/entity/History.java
+++ b/src/main/java/upbrella/be/rent/entity/History.java
@@ -41,7 +41,22 @@ public class History {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "refunded_by")
     private User refundedBy;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "paid_by")
+    private User paidBy;
     private String etc;
+
+    public void refund(User user, LocalDateTime refundedAt) {
+
+            this.refundedAt = refundedAt;
+            this.refundedBy = user;
+    }
+
+    public void paid(User user, LocalDateTime paidAt) {
+
+        this.paidBy = user;
+        this.paidAt = paidAt;
+    }
 
     public static History ofCreatedByNewRent(Umbrella umbrella, User user, StoreMeta rentStoreMeta) {
 

--- a/src/main/java/upbrella/be/rent/exception/NonExistingHistoryException.java
+++ b/src/main/java/upbrella/be/rent/exception/NonExistingHistoryException.java
@@ -1,0 +1,9 @@
+package upbrella.be.rent.exception;
+
+public class NonExistingHistoryException extends RuntimeException {
+
+    public NonExistingHistoryException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -165,8 +165,7 @@ public class RentService {
 
         User loginedUser = userService.findUserById(userId);
 
-        History history = rentRepository.findById(historyId)
-                .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
+        History history = findHistoryById(historyId);
 
         history.refund(loginedUser, LocalDateTime.now());
         rentRepository.save(history);
@@ -177,10 +176,13 @@ public class RentService {
 
         User loginedUser = userService.findUserById(userId);
 
-        History history = rentRepository.findById(historyId)
-                .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
-
+        History history = findHistoryById(historyId);
         history.paid(loginedUser, LocalDateTime.now());
         rentRepository.save(history);
+    }
+
+    private History findHistoryById(long historyId) {
+        return rentRepository.findById(historyId)
+                .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
     }
 }

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -10,6 +10,7 @@ import upbrella.be.rent.dto.response.RentFormResponse;
 import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
 import upbrella.be.rent.dto.response.RentalHistoryResponse;
 import upbrella.be.rent.entity.History;
+import upbrella.be.rent.exception.NonExistingHistoryException;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
@@ -18,6 +19,7 @@ import upbrella.be.umbrella.service.UmbrellaService;
 import upbrella.be.user.dto.response.AllHistoryResponse;
 import upbrella.be.user.dto.response.SingleHistoryResponse;
 import upbrella.be.user.entity.User;
+import upbrella.be.user.service.UserService;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -30,6 +32,7 @@ public class RentService {
     private final UmbrellaService umbrellaService;
     private final StoreMetaService storeMetaService;
     private final ImprovementReportService improvementReportService;
+    private final UserService userService;
     private final RentRepository rentRepository;
 
     public RentFormResponse findRentForm(long umbrellaId) {
@@ -155,5 +158,29 @@ public class RentService {
 
     public long countTotalRentByStoreId(long storeId) {
         return rentRepository.countByRentStoreMetaId(storeId);
+    }
+
+    @Transactional
+    public void checkRefund(long historyId, long userId) {
+
+        User loginedUser = userService.findUserById(userId);
+
+        History history = rentRepository.findById(historyId)
+                .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
+
+        history.refund(loginedUser, LocalDateTime.now());
+        rentRepository.save(history);
+    }
+
+    @Transactional
+    public void checkPayment(long historyId, long userId) {
+
+        User loginedUser = userService.findUserById(userId);
+
+        History history = rentRepository.findById(historyId)
+                .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
+
+        history.paid(loginedUser, LocalDateTime.now());
+        rentRepository.save(history);
     }
 }

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
         foundUser.withdrawUser();
     }
 
-    private User findUserById(Long id) {
+    public User findUserById(Long id) {
 
         return userRepository.findById(id)
                 .orElseThrow(() -> new NonExistingMemberException("[ERROR] 존재하지 않는 회원입니다."));

--- a/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
+++ b/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.payload.JsonFieldType;
 import upbrella.be.docs.utils.RestDocsSupport;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
@@ -24,6 +25,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -316,6 +318,56 @@ public class RentControllerTest extends RestDocsSupport {
                                 fieldWithPath("improvementReports[].etc").type(JsonFieldType.STRING)
                                         .optional()
                                         .description("기타 사항")
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("사용자는 특정 대여 내역을 환급 처리할 수 있다.")
+    void refundRentTest() throws Exception {
+
+        // given
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("userId", 2L);
+        doNothing().when(rentService)
+                .checkRefund(1L,2L);
+
+        mockMvc.perform(
+                        patch("/rent/histories/refund/{historyId}", 1L)
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("refund-rent-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("historyId")
+                                        .description("대여 내역 고유번호")
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("사용자는 특정 대여 내역을 입금 확인 처리할 수 있다.")
+    void checkPaymentTest() throws Exception {
+
+        // given
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("userId", 2L);
+        doNothing().when(rentService)
+                .checkPayment(1L,2L);
+
+        mockMvc.perform(
+                        patch("/rent/histories/payment/{historyId}", 1L)
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("check-payment-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("historyId")
+                                        .description("대여 내역 고유번호")
                         )));
 
     }

--- a/src/test/java/upbrella/be/rent/entity/HistoryTest.java
+++ b/src/test/java/upbrella/be/rent/entity/HistoryTest.java
@@ -12,6 +12,7 @@ import upbrella.be.user.entity.User;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 class HistoryTest {
 
@@ -192,5 +193,51 @@ class HistoryTest {
         assertThat(singleHistoryResponse)
                 .usingRecursiveComparison()
                 .isEqualTo(expectedResponse);
+    }
+
+    @Test
+    @DisplayName("환급 처리할 유저와 환급 처리 시각을 입력받아 해당 대여 내역을 환급 확인한다.")
+    void refundTest() {
+
+        //given
+        history = History.builder()
+                .id(33L)
+                .rentedAt(LocalDateTime.of(1000, 12, 3, 4, 24))
+                .returnedAt(LocalDateTime.of(1000, 12, 3, 4, 25))
+                .returnStoreMeta(foundStoreMeta)
+                .umbrella(foundUmbrella)
+                .user(userToRent)
+                .rentStoreMeta(foundStoreMeta)
+                .build();
+
+        // when
+        history.refund(userToRent, LocalDateTime.of(1000, 1, 2, 3, 4, 5));
+
+        // then
+        assertAll(() -> history.getRefundedBy().equals(userToRent),
+                  () -> history.getRefundedAt().equals(LocalDateTime.of(1000, 1, 2, 3, 4, 5)));
+    }
+
+    @Test
+    @DisplayName("지불 처리할 유저와 처리 시각을 입력받아 해당 대여 내역을 지불 확인 처리한다.")
+    void paidTest() {
+
+        //given
+        history = History.builder()
+                .id(33L)
+                .rentedAt(LocalDateTime.of(1000, 12, 3, 4, 24))
+                .returnedAt(LocalDateTime.of(1000, 12, 3, 4, 25))
+                .returnStoreMeta(foundStoreMeta)
+                .umbrella(foundUmbrella)
+                .user(userToRent)
+                .rentStoreMeta(foundStoreMeta)
+                .build();
+
+        // when
+        history.paid(userToRent, LocalDateTime.of(1000, 1, 2, 3, 4, 5));
+
+        // then
+        assertAll(() -> history.getPaidBy().equals(userToRent),
+                () -> history.getPaidAt().equals(LocalDateTime.of(1000, 1, 2, 3, 4, 5)));
     }
 }


### PR DESCRIPTION
## 🟢 구현내용

- #157 

## 🧩 고민과 해결과정
- 환급 확인, 지불 확인 기능 별도로 구현했습니다.
- 관리자가 체크하면 체크한 어드민 유저의 ID와 시각이 입력되는 방식입니다.
- 지불 확인은 시각 필드가 없어서 DB에 추가했습니다