### PR TITLE
[feat] redis session server 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,11 @@ dependencies {
 
     // Test용 H2 In-memory DB
     testImplementation group: 'com.h2database', name: 'h2', version: '1.4.200'
+
+    // Spring Data Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    // Spring Session Data Redis
+    implementation 'org.springframework.session:spring-session-data-redis'
 }
 
 ext {

--- a/src/main/java/upbrella/be/config/HttpSessionConfig.java
+++ b/src/main/java/upbrella/be/config/HttpSessionConfig.java
@@ -1,0 +1,10 @@
+package upbrella.be.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 1800)
+@Configuration
+public class HttpSessionConfig {
+
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,8 +10,15 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        show-sql: true
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    timeout: 60000
+  session:
+    store-type: redis
+    timeout: 3600
 
-    show-sql: true
 logging:
   level:
     org:
@@ -20,3 +27,4 @@ logging:
         type:
           descriptor:
             sql: trace
+


### PR DESCRIPTION
## 🟢 구현내용

- #134 
- redis 설정하여 분산서버에서도 세션을 통한 로그인이 작동하도록 하였습니다. 
- redis session server 이용 방법은 기존과 동일하게 session.setAttribute() 를 이용하면 됩니다.

## 🧩 고민과 해결과정

- 