### PR TITLE
[refactor] 유저 로그인 플로우 개선 (#165)

### DIFF
--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -8,6 +8,14 @@ include::{snippets}/user-login-doc/http-request.adoc[]
 
 include::{snippets}/user-login-doc/http-response.adoc[]
 
+=== 카카오 로그인을 통한 업브렐라 로그인
+
+==== HTTP Request
+include::{snippets}/user-upbrella-login-doc/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/user-upbrella-login-doc/http-response.adoc[]
+
 === 회원 가입
 
 ==== HTTP Request

--- a/src/main/java/upbrella/be/config/AuthConfig.java
+++ b/src/main/java/upbrella/be/config/AuthConfig.java
@@ -5,6 +5,8 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import upbrella.be.config.interceptor.AdminInterceptor;
+import upbrella.be.config.interceptor.LoginInterceptor;
 import upbrella.be.config.interceptor.OAuthLoginInterceptor;
 
 @Profile(value = "!dev")
@@ -13,6 +15,8 @@ import upbrella.be.config.interceptor.OAuthLoginInterceptor;
 public class AuthConfig implements WebMvcConfigurer {
 
     private final OAuthLoginInterceptor oAuthLoginInterceptor;
+    private final LoginInterceptor loginInterceptor;
+    private final AdminInterceptor adminInterceptor;
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
@@ -25,5 +29,9 @@ public class AuthConfig implements WebMvcConfigurer {
                         "/error/**",
                         "/api/error/**",
                         "/docs/**");
+
+        registry.addInterceptor(loginInterceptor);
+
+        registry.addInterceptor(adminInterceptor);
     }
 }

--- a/src/main/java/upbrella/be/config/interceptor/AdminInterceptor.java
+++ b/src/main/java/upbrella/be/config/interceptor/AdminInterceptor.java
@@ -1,0 +1,31 @@
+package upbrella.be.config.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+import upbrella.be.user.dto.response.SessionUser;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Component
+public class AdminInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return false;
+        }
+        if (session.getAttribute("user") != null) {
+            SessionUser user = (SessionUser) session.getAttribute("user");
+            if (user.isAdminStatus() == false) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/upbrella/be/config/interceptor/LoginInterceptor.java
+++ b/src/main/java/upbrella/be/config/interceptor/LoginInterceptor.java
@@ -1,0 +1,27 @@
+package upbrella.be.config.interceptor;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+@Component
+public class LoginInterceptor implements HandlerInterceptor {
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
+
+        HttpSession session = request.getSession(false);
+
+        if (session == null) {
+            return false;
+        }
+        if (session.getAttribute("user") != null) {
+            request.setAttribute("user", session.getAttribute("user"));
+        }
+
+        return true;
+    }
+}

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -107,7 +107,7 @@ public class UserController {
                 .body(new CustomResponse<>(
                         "success",
                         200,
-                        "카카오 로그인 성공",
+                        "업브렐라 로그인 성공",
                         null));
     }
 

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -62,20 +62,9 @@ public class UserController {
     @GetMapping("/loggedIn/umbrella")
     public ResponseEntity<CustomResponse<UmbrellaBorrowedByUserResponse>> findUmbrellaBorrowedByUser(HttpSession httpSession) {
 
-        /**
-         * TODO: 세션 처리으로 로그인한 유저의 id 가져오기
-         *       interceptor에서 userId를 가져올 것인지, user 객체를 가져올 것인지 논의 후 구현
-         */
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
 
-        // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
-        User loggedInUser = User.builder()
-                .id(72L)
-                .name("사용자")
-                .phoneNumber("010-1234-5678")
-                .adminStatus(false)
-                .build();
-
-        History rentalHistory = rentRepository.findByUserAndReturnedAtIsNull(loggedInUser.getId())
+        History rentalHistory = rentRepository.findByUserAndReturnedAtIsNull(sessionUser.getId())
                 .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자가 빌린 우산이 없습니다."));
 
         long borrowedUmbrellaUuid = rentalHistory.getUmbrella().getUuid();

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -96,11 +96,15 @@ public class UserController {
     @GetMapping("/login")
     public ResponseEntity<CustomResponse> upbrellaLogin(HttpSession session) {
 
+        if (session.getAttribute("kakaoId") == null) {
+            throw new NotSocialLoginedException("[ERROR] 카카오 로그인을 먼저 해주세요.");
+        }
+
         Long kakaoId = (Long) session.getAttribute("kakaoId");
-        SessionUser loginedUserId = userService.login(kakaoId);
+        SessionUser loggedInUser = userService.login(kakaoId);
 
         session.removeAttribute("kakaoId");
-        session.setAttribute("user", loginedUserId);
+        session.setAttribute("user", loggedInUser);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -182,7 +182,7 @@ public class UserController {
                 ));
     }
 
-    @DeleteMapping("loggedIn")
+    @DeleteMapping("/loggedIn")
     public ResponseEntity<CustomResponse> deleteUser(HttpSession session) {
 
         long loginedUserId = (long) session.getAttribute("userId");

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -37,18 +37,8 @@ public class UserController {
     @GetMapping("/loggedIn")
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
 
-        /**
-         * TODO: 세션 처리으로 로그인한 유저의 id 가져오기
-         *       interceptor에서 userId를 가져올 것인지, user 객체를 가져올 것인지 논의 후 구현
-         */
-
-        // session에서 꺼낸 것이라는 의미로 repository로부터 findById를 하지 않고 빌더를 사용해서 만들었음.
-        User loggedInUser = User.builder()
-                .id(1L)
-                .name("사용자")
-                .phoneNumber("010-0000-0000")
-                .adminStatus(false)
-                .build();
+        SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
+        User user = userService.findUserById(sessionUser.getId());
 
         return ResponseEntity
                 .ok()
@@ -56,7 +46,7 @@ public class UserController {
                         "success",
                         200,
                         "로그인 유저 정보 조회 성공",
-                        UserInfoResponse.fromUser(loggedInUser)));
+                        UserInfoResponse.fromUser(user)));
     }
 
     @GetMapping("/loggedIn/umbrella")

--- a/src/main/java/upbrella/be/user/dto/response/SessionUser.java
+++ b/src/main/java/upbrella/be/user/dto/response/SessionUser.java
@@ -1,0 +1,27 @@
+package upbrella.be.user.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import upbrella.be.user.entity.User;
+
+@Getter
+@Builder
+public class SessionUser {
+
+    private long id;
+    private long socialId;
+    private String name;
+    private String phoneNumber;
+    private boolean adminStatus;
+
+    public static SessionUser fromUser(User user) {
+
+        return SessionUser.builder()
+                .id(user.getId())
+                .socialId(user.getSocialId())
+                .name(user.getName())
+                .phoneNumber(user.getPhoneNumber())
+                .adminStatus(user.isAdminStatus())
+                .build();
+    }
+}

--- a/src/main/java/upbrella/be/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/UserInfoResponse.java
@@ -11,12 +11,17 @@ public class UserInfoResponse {
     private long id;
     private String name;
     private String phoneNumber;
+    private String bank;
+    private String accountNumber;
 
     public static UserInfoResponse fromUser(User user) {
+
         return UserInfoResponse.builder()
                 .id(user.getId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
+                .bank(user.getBank())
+                .accountNumber(user.getAccountNumber())
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.AllUsersInfoResponse;
+import upbrella.be.user.dto.response.SessionUser;
 import upbrella.be.user.entity.BlackList;
 import upbrella.be.user.entity.User;
 import upbrella.be.user.exception.BlackListUserException;
@@ -21,15 +22,15 @@ public class UserService {
     private final UserRepository userRepository;
     private final BlackListRepository blackListRepository;
 
-    public long login(Long socialId) {
+    public SessionUser login(Long socialId) {
 
         User foundUser = userRepository.findBySocialId(socialId)
                 .orElseThrow(() -> new NonExistingMemberException("[ERROR] 존재하지 않는 회원입니다. 회원 가입을 해주세요."));
 
-        return foundUser.getId();
+        return SessionUser.fromUser(foundUser);
     }
 
-    public long join(long socialId, JoinRequest joinRequest) {
+    public SessionUser join(long socialId, JoinRequest joinRequest) {
 
         if (userRepository.existsBySocialId(socialId)) {
             throw new ExistingMemberException("[ERROR] 이미 가입된 회원입니다. 로그인 폼으로 이동합니다.");
@@ -40,7 +41,7 @@ public class UserService {
 
         User joinedUser = userRepository.save(User.createNewUser(socialId, joinRequest));
 
-        return joinedUser.getId();
+        return SessionUser.fromUser(joinedUser);
     }
 
     public AllUsersInfoResponse findUsers() {

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,7 +15,6 @@ spring:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
     timeout: 60000
-    password: ${REDIS_PASSWORD}
   session:
     store-type: redis
     timeout: 3600

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -15,6 +15,7 @@ spring:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
     timeout: 60000
+    password: ${REDIS_PASSWORD}
   session:
     store-type: redis
     timeout: 3600

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -15,6 +15,7 @@ import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
+import upbrella.be.user.dto.response.SessionUser;
 import upbrella.be.user.dto.response.SingleHistoryResponse;
 import upbrella.be.user.entity.User;
 
@@ -188,4 +189,13 @@ public class FixtureBuilderFactory {
                 .set("id", buildLong(100));
     }
 
+    public static ArbitraryBuilder<SessionUser> builderSessionUser() {
+
+        return fixtureMonkey.giveMeBuilder(SessionUser.class)
+                .set("id", buildLong(100))
+                .set("socialId", buildLong(100))
+                .set("adminStatus", false)
+                .set("name", pickRandomString(nameList))
+                .set("phoneNumber", pickPhoneNumberString());
+    }
 }

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -69,10 +69,19 @@ public class UserControllerTest extends RestDocsSupport {
     @DisplayName("사용자는 로그인된 유저 정보를 조회할 수 있다.")
     @Test
     void findUserInfoTest() throws Exception {
+        // given
+        MockHttpSession session = new MockHttpSession();
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        User user = FixtureBuilderFactory.builderUser().sample();
+
+        session.setAttribute("user", sessionUser);
+        given(userService.findUserById(anyLong()))
+                .willReturn(user);
 
         // when & then
         mockMvc.perform(
                         get("/users/loggedIn")
+                                .session(session)
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("find-user-info-doc",
@@ -85,7 +94,11 @@ public class UserControllerTest extends RestDocsSupport {
                                 fieldWithPath("name").type(JsonFieldType.STRING)
                                         .description("사용자 이름"),
                                 fieldWithPath("phoneNumber").type(JsonFieldType.STRING)
-                                        .description("사용자 전화번호")
+                                        .description("사용자 전화번호"),
+                                fieldWithPath("bank").type(JsonFieldType.STRING)
+                                        .description("사용자 은행"),
+                                fieldWithPath("accountNumber").type(JsonFieldType.STRING)
+                                        .description("사용자 계좌번호")
                         )));
     }
 

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -29,6 +29,7 @@ import upbrella.be.user.exception.*;
 import upbrella.be.user.service.OauthLoginService;
 import upbrella.be.user.service.UserService;
 
+import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -215,6 +216,30 @@ public class UserControllerTest extends RestDocsSupport {
                     .andExpect(result ->
                             assertThat(result.getResolvedException())
                                     .isInstanceOf(InvalidLoginCodeException.class));
+        }
+
+        @Test
+        @DisplayName("회원인 경우 로그인이 진행된다.")
+        void upbrellaLoginTest() throws Exception {
+            // given
+            MockHttpSession session = new MockHttpSession();
+
+            SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+            session.setAttribute("kakaoId", 123123L);
+            given(userService.login(any())).willReturn(sessionUser);
+
+            // when
+
+            // then
+            mockMvc.perform(
+                            get("/users/login")
+                                    .session(session)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andDo(document("user-upbrella-login-doc",
+                            getDocumentRequest(),
+                            getDocumentResponse()
+                    ));
         }
     }
 

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -93,6 +93,11 @@ public class UserControllerTest extends RestDocsSupport {
     @DisplayName("사용자는 유저가 빌린 우산을 조회할 수 있다.")
     void findUmbrellaBorrowedByUserTest() throws Exception {
         // given
+        MockHttpSession httpSession = new MockHttpSession();
+        SessionUser user = FixtureBuilderFactory.builderSessionUser().sample();
+
+        httpSession.setAttribute("user", user);
+
         Umbrella borrowedUmbrella = FixtureBuilderFactory.builderUmbrella().sample();
         History rentalHistory = FixtureFactory.buildHistoryWithUmbrella(borrowedUmbrella);
 
@@ -102,6 +107,7 @@ public class UserControllerTest extends RestDocsSupport {
         // when
         mockMvc.perform(
                         get("/users/loggedIn/umbrella")
+                                .session(httpSession)
                 ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("find-umbrella-borrowed-by-user-doc",

--- a/src/test/java/upbrella/be/user/service/UserServiceDynamicTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceDynamicTest.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.user.dto.request.JoinRequest;
+import upbrella.be.user.dto.response.SessionUser;
 import upbrella.be.user.exception.ExistingMemberException;
 import upbrella.be.user.entity.User;
 import upbrella.be.user.exception.NonExistingMemberException;
@@ -51,8 +52,8 @@ class UserServiceDynamicTest {
 
         return List.of(
                 DynamicTest.dynamicTest("새로 가입한 유저는 DB에 저장된다.", () -> {
-                    long joined = userService.join(user.getSocialId(), joinRequest);
-                    Optional<User> foundUser = userRepository.findById(joined);
+                    SessionUser joined = userService.join(user.getSocialId(), joinRequest);
+                    Optional<User> foundUser = userRepository.findById(joined.getId());
 
                     assertAll(() -> assertTrue(foundUser.isPresent()),
                             () -> assertEquals(user.getName(), foundUser.get().getName()),
@@ -72,8 +73,8 @@ class UserServiceDynamicTest {
                             .isInstanceOf(NonExistingMemberException.class);
                 }),
                 DynamicTest.dynamicTest("회원 가입한 아이디로 로그인할 수 있다.", () -> {
-                    long logined = userService.login(user.getSocialId());
-                    Optional<User> foundUser = userRepository.findById(logined);
+                    SessionUser logined = userService.login(user.getSocialId());
+                    Optional<User> foundUser = userRepository.findById(logined.getId());
 
                     assertAll(() -> assertTrue(foundUser.isPresent()),
                             () -> assertEquals(user.getName(), foundUser.get().getName()),

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -13,6 +13,7 @@ import upbrella.be.config.FixtureFactory;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.AllUsersInfoResponse;
+import upbrella.be.user.dto.response.SessionUser;
 import upbrella.be.user.dto.response.SingleUserInfoResponse;
 import upbrella.be.user.entity.BlackList;
 import upbrella.be.user.entity.User;
@@ -68,11 +69,11 @@ class UserServiceTest {
                     .willReturn(Optional.of(user));
 
             // when
-            long loginedUserId = userService.login(user.getSocialId());
+            SessionUser loginedUserId = userService.login(user.getSocialId());
 
             // then
             assertAll(
-                    () -> assertThat(loginedUserId).isEqualTo(user.getId()),
+                    () -> assertThat(loginedUserId.getId()).isEqualTo(user.getId()),
                     () -> then(userRepository).should(times(1))
                             .findBySocialId(user.getSocialId()));
         }
@@ -122,11 +123,11 @@ class UserServiceTest {
                     .willReturn(user);
 
             // when
-            long joinedUserId = userService.join(notExistingSocialId, joinRequest);
+            SessionUser joinedUserId = userService.join(notExistingSocialId, joinRequest);
 
             // then
             assertAll(
-                    () -> assertThat(joinedUserId).isEqualTo(user.getId()),
+                    () -> assertThat(joinedUserId.getId()).isEqualTo(user.getId()),
                     () -> then(userRepository).should(times(1))
                             .save(any(User.class)),
                     () -> then(userRepository).should(times(1))


### PR DESCRIPTION
## 🟢 구현내용
- #165 

## 🧩 고민과 해결과정
- 로그인 플로우를 수정하였습니다. 
- 기존 
1. 유저 카카오 로그인 
2. UserController Login method 하나에서 카카오 로그인과 업브렐라 로그인 로직을 담당 

- 수정 후 
1. 유저가 카카오 로그인 
2. Controller에서 카카오 로그인과 업브렐라 로그인 구분 
3. 업브렐라 로그인에서 회원이 아닐 경우 회원가입 할 수 있도록 에러로그 출력 