### PR TITLE
[fix] 사용자 대여 우산 조회, 대여 내역 조회, 은행 정보 수정 500 에러 수정, CORS OPTIONS 추가(#198, #200)

### DIFF
--- a/src/main/java/upbrella/be/config/WebConfig.java
+++ b/src/main/java/upbrella/be/config/WebConfig.java
@@ -13,7 +13,7 @@ public class WebConfig implements WebMvcConfigurer {
         //TODO: CORS 세부 설정 예정
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000", "http://upbrella-dev.site:80")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD")
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS")
                 .allowCredentials(true)
                 .allowedHeaders("*");
     }

--- a/src/main/java/upbrella/be/rent/repository/RentRepository.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepository.java
@@ -7,8 +7,6 @@ import java.util.Optional;
 
 public interface RentRepository extends JpaRepository<History, Long>, RentRepositoryCustom {
 
-    Optional<History> findByUserAndReturnedAtIsNull(Long userId);
-
     Optional<History> findByUserIdAndReturnedAtIsNull(Long userId);
 
     long countByRentStoreMetaId(long storeId);

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -15,8 +15,10 @@ import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
 import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
 import upbrella.be.umbrella.service.UmbrellaService;
 import upbrella.be.user.dto.response.AllHistoryResponse;
+import upbrella.be.user.dto.response.SessionUser;
 import upbrella.be.user.dto.response.SingleHistoryResponse;
 import upbrella.be.user.entity.User;
 import upbrella.be.user.service.UserService;
@@ -189,5 +191,11 @@ public class RentService {
     private History findHistoryById(long historyId) {
         return rentRepository.findById(historyId)
                 .orElseThrow(() -> new NonExistingHistoryException("[ERROR] 해당 대여 기록이 없습니다."));
+    }
+
+    public History findRentalHistoryByUser(SessionUser sessionUser) {
+
+        return rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId())
+                .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaExceptionHandler.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaExceptionHandler.java
@@ -29,7 +29,7 @@ public class UmbrellaExceptionHandler {
                 .badRequest()
                 .body(new CustomErrorResponse(
                         "fail",
-                        400,
+                        404,
                         "존재하지 않는 우산 고유 번호입니다."));
     }
 
@@ -40,7 +40,7 @@ public class UmbrellaExceptionHandler {
                 .badRequest()
                 .body(new CustomErrorResponse(
                         "fail",
-                        400,
+                        404,
                         "사용자가 빌린 우산이 없습니다."));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/controller/UmbrellaExceptionHandler.java
+++ b/src/main/java/upbrella/be/umbrella/controller/UmbrellaExceptionHandler.java
@@ -4,6 +4,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
+import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
 import upbrella.be.umbrella.exception.NonExistingUmbrellaException;
 import upbrella.be.util.CustomErrorResponse;
 
@@ -30,5 +31,16 @@ public class UmbrellaExceptionHandler {
                         "fail",
                         400,
                         "존재하지 않는 우산 고유 번호입니다."));
+    }
+
+    @ExceptionHandler(NonExistingBorrowedHistoryException.class)
+    public ResponseEntity<CustomErrorResponse> nonExistingBorrowedHistory(NonExistingBorrowedHistoryException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "fail",
+                        400,
+                        "사용자가 빌린 우산이 없습니다."));
     }
 }

--- a/src/main/java/upbrella/be/umbrella/exception/NonExistingBorrowedHistoryException.java
+++ b/src/main/java/upbrella/be/umbrella/exception/NonExistingBorrowedHistoryException.java
@@ -3,6 +3,7 @@ package upbrella.be.umbrella.exception;
 public class NonExistingBorrowedHistoryException extends RuntimeException {
 
     public NonExistingBorrowedHistoryException(String message) {
+
         super(message);
     }
 }

--- a/src/main/java/upbrella/be/umbrella/exception/NonExistingBorrowedHistoryException.java
+++ b/src/main/java/upbrella/be/umbrella/exception/NonExistingBorrowedHistoryException.java
@@ -1,0 +1,8 @@
+package upbrella.be.umbrella.exception;
+
+public class NonExistingBorrowedHistoryException extends RuntimeException {
+
+    public NonExistingBorrowedHistoryException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -7,6 +7,7 @@ import org.springframework.web.client.HttpClientErrorException;
 import upbrella.be.rent.entity.History;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.rent.service.RentService;
+import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.*;
@@ -53,16 +54,15 @@ public class UserController {
     public ResponseEntity<CustomResponse<UmbrellaBorrowedByUserResponse>> findUmbrellaBorrowedByUser(HttpSession httpSession) {
 
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-
-        History rentalHistory = rentRepository.findByUserAndReturnedAtIsNull(sessionUser.getId())
-                .orElseThrow(() -> new IllegalArgumentException("[ERROR] 사용자가 빌린 우산이 없습니다."));
+        History rentalHistory = rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId())
+                .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
 
         long borrowedUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
 
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
-                        "success",
+                  정      "success",
                         200,
                         "사용자가 빌린 우산 조회 성공",
                         UmbrellaBorrowedByUserResponse.builder()

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
-import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.rent.service.RentService;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
@@ -30,7 +29,6 @@ public class UserController {
     private final OauthLoginService oauthLoginService;
     private final UserService userService;
     private final KakaoOauthInfo kakaoOauthInfo;
-    private final RentRepository rentRepository;
     private final RentService rentService;
 
     @GetMapping("/loggedIn")
@@ -166,11 +164,11 @@ public class UserController {
     }
 
     @PatchMapping("/bankAccount")
-    public ResponseEntity<CustomResponse> updateUserBankAccount(HttpSession session, @Valid @RequestBody UpdateBankAccountRequest updateBankAccountRequest) {
+    public ResponseEntity<CustomResponse> updateUserBankAccount(@Valid @RequestBody UpdateBankAccountRequest updateBankAccountRequest, HttpSession session) {
 
-        long loginedUserId = (long) session.getAttribute("userId");
+        SessionUser sessionUser = (SessionUser) session.getAttribute("user");
 
-        userService.updateUserBankAccount(loginedUserId, updateBankAccountRequest);
+        userService.updateUserBankAccount(sessionUser.getId(), updateBankAccountRequest);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -4,10 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.client.HttpClientErrorException;
-import upbrella.be.rent.entity.History;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.rent.service.RentService;
-import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.*;
@@ -54,20 +52,17 @@ public class UserController {
     public ResponseEntity<CustomResponse<UmbrellaBorrowedByUserResponse>> findUmbrellaBorrowedByUser(HttpSession httpSession) {
 
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        History rentalHistory = rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId())
-                .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
 
-        long borrowedUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
+        UmbrellaBorrowedByUserResponse umbrellaBorrowedByUserResponse = userService.findUmbrellaBorrowedByUser(sessionUser);
 
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
-                  정      "success",
+                        "success",
                         200,
                         "사용자가 빌린 우산 조회 성공",
-                        UmbrellaBorrowedByUserResponse.builder()
-                                .uuid(borrowedUmbrellaUuid)
-                                .build()));
+                        umbrellaBorrowedByUserResponse
+                        ));
     }
 
     @GetMapping("/oauth/login")

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -153,7 +153,7 @@ public class UserController {
     @GetMapping("/histories")
     public ResponseEntity<CustomResponse> readUserHistories(HttpSession session) {
 
-        long loginedUserId = (long) session.getAttribute("userId");
+        SessionUser sessionUser = (SessionUser)session.getAttribute("user");
 
         return ResponseEntity
                 .ok()
@@ -161,7 +161,7 @@ public class UserController {
                         "success",
                         200,
                         "사용자 대여 목록 조회 성공",
-                        rentService.findAllHistoriesByUser(loginedUserId)
+                        rentService.findAllHistoriesByUser(sessionUser.getId())
                 ));
     }
 

--- a/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
@@ -8,4 +8,10 @@ import lombok.Getter;
 public class UmbrellaBorrowedByUserResponse {
 
     private long uuid;
+
+    public static UmbrellaBorrowedByUserResponse of(long uuid) {
+        return UmbrellaBorrowedByUserResponse.builder()
+                .uuid(uuid)
+                .build();
+    }
 }

--- a/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/UmbrellaBorrowedByUserResponse.java
@@ -10,6 +10,7 @@ public class UmbrellaBorrowedByUserResponse {
     private long uuid;
 
     public static UmbrellaBorrowedByUserResponse of(long uuid) {
+
         return UmbrellaBorrowedByUserResponse.builder()
                 .uuid(uuid)
                 .build();

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -1,11 +1,10 @@
 package upbrella.be.user.service;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.rent.entity.History;
-import upbrella.be.rent.repository.RentRepository;
-import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
+import upbrella.be.rent.service.RentService;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.AllUsersInfoResponse;
@@ -20,12 +19,16 @@ import upbrella.be.user.repository.BlackListRepository;
 import upbrella.be.user.repository.UserRepository;
 
 @Service
-@RequiredArgsConstructor
 public class UserService {
+    public UserService(UserRepository userRepository, BlackListRepository blackListRepository, @Lazy RentService rentService) {
+        this.userRepository = userRepository;
+        this.blackListRepository = blackListRepository;
+        this.rentService = rentService;
+    }
 
     private final UserRepository userRepository;
     private final BlackListRepository blackListRepository;
-    private final RentRepository rentRepository;
+    private final RentService rentService;
 
     public SessionUser login(Long socialId) {
 
@@ -56,8 +59,7 @@ public class UserService {
 
     public UmbrellaBorrowedByUserResponse findUmbrellaBorrowedByUser(SessionUser sessionUser) {
 
-        History rentalHistory = rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId())
-                .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
+        History rentalHistory = rentService.findRentalHistoryByUser(sessionUser);
 
         long borrowedUmbrellaUuid = rentalHistory.getUmbrella().getUuid();
 

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -5,6 +5,7 @@ import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
 import com.navercorp.fixturemonkey.api.random.Randoms;
 import net.jqwik.api.Arbitraries;
+import upbrella.be.rent.entity.History;
 import upbrella.be.store.entity.BusinessHour;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.StoreMeta;
@@ -197,5 +198,18 @@ public class FixtureBuilderFactory {
                 .set("adminStatus", false)
                 .set("name", pickRandomString(nameList))
                 .set("phoneNumber", pickPhoneNumberString());
+    }
+
+    public static ArbitraryBuilder<History> builderHistory() {
+
+        return fixtureMonkey.giveMeBuilder(History.class)
+                .set("id", buildLong(100))
+                .set("umbrella", builderUmbrella().sample())
+                .set("user", builderUser().sample())
+                .set("bank", pickRandomString(bankList))
+                .set("accountNumber", pickAccountNumberString())
+                .set("returnStoreMeta", builderStoreMeta().sample())
+                .set("rentStoreMeta", builderStoreMeta().sample())
+                .set("etc", pickRandomString(nameList));
     }
 }

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.config.FixtureFactory;
 import upbrella.be.docs.utils.RestDocsSupport;
-import upbrella.be.rent.entity.History;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.rent.service.RentService;
 import upbrella.be.umbrella.entity.Umbrella;
@@ -29,10 +28,8 @@ import upbrella.be.user.exception.*;
 import upbrella.be.user.service.OauthLoginService;
 import upbrella.be.user.service.UserService;
 
-import javax.servlet.http.HttpSession;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -113,10 +110,9 @@ public class UserControllerTest extends RestDocsSupport {
         httpSession.setAttribute("user", user);
 
         Umbrella borrowedUmbrella = FixtureBuilderFactory.builderUmbrella().sample();
-        History rentalHistory = FixtureFactory.buildHistoryWithUmbrella(borrowedUmbrella);
 
-        given(rentRepository.findByUserAndReturnedAtIsNull(anyLong()))
-                .willReturn(Optional.ofNullable(rentalHistory));
+        given(userService.findUmbrellaBorrowedByUser(user))
+                .willReturn(UmbrellaBorrowedByUserResponse.of(borrowedUmbrella.getUuid()));
 
         // when
         mockMvc.perform(

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -420,9 +420,10 @@ public class UserControllerTest extends RestDocsSupport {
 
         AllHistoryResponse historyResponse = AllHistoryResponse.of(historyResponses);
 
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
         MockHttpSession mockHttpSession = new MockHttpSession();
-        mockHttpSession.setAttribute("userId", 70L);
-        given(rentService.findAllHistoriesByUser(70L))
+        mockHttpSession.setAttribute("user", sessionUser);
+        given(rentService.findAllHistoriesByUser(sessionUser.getId()))
                 .willReturn(historyResponse);
 
         // when & then

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -15,7 +15,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.config.FixtureFactory;
 import upbrella.be.docs.utils.RestDocsSupport;
-import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.rent.service.RentService;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
@@ -55,13 +54,11 @@ public class UserControllerTest extends RestDocsSupport {
     @Mock
     private KakaoOauthInfo kakaoOauthInfo;
     @Mock
-    private RentRepository rentRepository;
-    @Mock
     private RentService rentService;
 
     @Override
     protected Object initController() {
-        return new UserController(oauthLoginService, userService, kakaoOauthInfo, rentRepository, rentService);
+        return new UserController(oauthLoginService, userService, kakaoOauthInfo, rentService);
     }
 
     @DisplayName("사용자는 로그인된 유저 정보를 조회할 수 있다.")
@@ -461,7 +458,8 @@ public class UserControllerTest extends RestDocsSupport {
         // given
         UpdateBankAccountRequest updateBankAccountRequest = FixtureBuilderFactory.builderBankAccount().sample();
         MockHttpSession mockHttpSession = new MockHttpSession();
-        mockHttpSession.setAttribute("userId", 70L);
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        mockHttpSession.setAttribute("user", sessionUser);
 
         // when
 

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -11,8 +11,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.config.FixtureFactory;
 import upbrella.be.rent.entity.History;
-import upbrella.be.rent.repository.RentRepository;
-import upbrella.be.umbrella.exception.NonExistingBorrowedHistoryException;
+import upbrella.be.rent.service.RentService;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
 import upbrella.be.user.dto.response.AllUsersInfoResponse;
@@ -48,7 +47,7 @@ class UserServiceTest {
     @Mock
     private BlackListRepository blackListRepository;
     @Mock
-    private RentRepository rentRepository;
+    private RentService rentService;
     @InjectMocks
     private UserService userService;
 
@@ -178,8 +177,8 @@ class UserServiceTest {
         void success() {
 
             // given
-            given(rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId()))
-                    .willReturn(Optional.of(history));
+            given(rentService.findRentalHistoryByUser(sessionUser))
+                    .willReturn(history);
 
             // when
             UmbrellaBorrowedByUserResponse umbrellaBorrowedByUser = userService.findUmbrellaBorrowedByUser(sessionUser);
@@ -188,24 +187,8 @@ class UserServiceTest {
             assertAll(
                     () -> assertThat(umbrellaBorrowedByUser.getUuid())
                             .isEqualTo(history.getUmbrella().getUuid()),
-                    () -> then(rentRepository).should(times(1))
-                            .findByUserIdAndReturnedAtIsNull(sessionUser.getId()));
-        }
-
-        @Test
-        @DisplayName("빌린 우산이 없으면 예외가 반환된다.")
-        void nonExistingBorrowedUmbrella() {
-
-            // given
-            given(rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId()))
-                    .willReturn(Optional.ofNullable(null));
-
-            // when & then
-            assertAll(
-                    () -> assertThatThrownBy(() -> userService.findUmbrellaBorrowedByUser(sessionUser))
-                            .isInstanceOf(NonExistingBorrowedHistoryException.class),
-                    () -> then(rentRepository).should(times(1))
-                            .findByUserIdAndReturnedAtIsNull(sessionUser.getId()));
+                    () -> then(rentService).should(times(1))
+                            .findRentalHistoryByUser(sessionUser));
         }
     }
 


### PR DESCRIPTION
## 🟢 구현내용
- #198 
- #200 

## 🧩 고민과 해결과정
- 대부분 세션 변경 후 ID 타입으로 남아있어 생기는 버그여서 수정했습니다.
- CORS 프리플라이트 요청(OPTION) 에러 발생안하도록 OPTIONS 메서드 추가했습니다.