### PR TITLE
[fix] 세션 유저 변경 및 암호화 관련 버그 수정

### DIFF
--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -133,9 +133,9 @@ public class RentController {
     @PatchMapping("/histories/refund/{historyId}")
     public ResponseEntity<CustomResponse> refundRent(@PathVariable long historyId, HttpSession httpSession) {
 
-        long loginedUserId = (long) httpSession.getAttribute("userId");
+        SessionUser loginedUser = (SessionUser) httpSession.getAttribute("user");
 
-        rentService.checkRefund(historyId, loginedUserId);
+        rentService.checkRefund(historyId, loginedUser.getId());
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse(
@@ -148,9 +148,9 @@ public class RentController {
     @PatchMapping("/histories/payment/{historyId}")
     public ResponseEntity<CustomResponse> checkPayment(@PathVariable long historyId, HttpSession httpSession) {
 
-        long loginedUserId = (long) httpSession.getAttribute("userId");
+        SessionUser loginedUser = (SessionUser) httpSession.getAttribute("user");
 
-        rentService.checkPayment(historyId, loginedUserId);
+        rentService.checkPayment(historyId, loginedUser.getId());
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse(

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -182,9 +182,9 @@ public class UserController {
     @DeleteMapping("/loggedIn")
     public ResponseEntity<CustomResponse> deleteUser(HttpSession session) {
 
-        long loginedUserId = (long) session.getAttribute("userId");
+        SessionUser loginedUser = (SessionUser) session.getAttribute("user");
 
-        userService.deleteUser(loginedUserId);
+        userService.deleteUser(loginedUser.getId());
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
 
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        User user = userService.findUserById(sessionUser.getId());
+        User user = userService.findDecryptedUserById(sessionUser.getId());
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/user/entity/User.java
+++ b/src/main/java/upbrella/be/user/entity/User.java
@@ -68,8 +68,14 @@ public class User {
 
     public User decryptData() {
 
-        this.bank = AesEncryptor.decrypt(this.bank);
-        this.accountNumber = AesEncryptor.decrypt(this.accountNumber);
-        return this;
+        return User.builder()
+                .id(this.id)
+                .socialId(this.socialId)
+                .name(this.name)
+                .phoneNumber(this.phoneNumber)
+                .adminStatus(this.adminStatus)
+                .bank(AesEncryptor.decrypt(this.bank))
+                .accountNumber(AesEncryptor.decrypt(this.accountNumber))
+                .build();
     }
 }

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -102,7 +102,16 @@ public class UserService {
     public User findUserById(Long id) {
 
         return userRepository.findById(id)
+                .orElseThrow(() -> new NonExistingMemberException("[ERROR] 존재하지 않는 회원입니다."));
+    }
+
+
+    public User findDecryptedUserById(Long id) {
+
+        // Deep copy 객체를 반환함에 유의
+        return userRepository.findById(id)
                 .orElseThrow(() -> new NonExistingMemberException("[ERROR] 존재하지 않는 회원입니다."))
                 .decryptData();
     }
+
 }

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -35,18 +35,18 @@ public class UserService {
 
     public SessionUser login(Long socialId) {
 
-        User foundUser = userRepository.findBySocialId(socialId)
+        User foundUser = userRepository.findBySocialId((long) socialId.hashCode())
                 .orElseThrow(() -> new NonExistingMemberException("[ERROR] 존재하지 않는 회원입니다. 회원 가입을 해주세요."));
 
         return SessionUser.fromUser(foundUser);
     }
 
-    public SessionUser join(long socialId, JoinRequest joinRequest) {
+    public SessionUser join(Long socialId, JoinRequest joinRequest) {
 
-        if (userRepository.existsBySocialId(socialId)) {
+        if (userRepository.existsBySocialId((long) socialId.hashCode())) {
             throw new ExistingMemberException("[ERROR] 이미 가입된 회원입니다. 로그인 폼으로 이동합니다.");
         }
-        if(blackListRepository.existsBySocialId(socialId)){
+        if(blackListRepository.existsBySocialId((long) socialId.hashCode())) {
             throw new BlackListUserException("[ERROR] 정지된 회원입니다. 정지된 회원은 재가입이 불가능합니다.");
         }
 

--- a/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
+++ b/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
+import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.docs.utils.RestDocsSupport;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;
@@ -372,9 +373,10 @@ public class RentControllerTest extends RestDocsSupport {
 
         // given
         MockHttpSession mockHttpSession = new MockHttpSession();
-        mockHttpSession.setAttribute("userId", 2L);
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        mockHttpSession.setAttribute("user", sessionUser);
         doNothing().when(rentService)
-                .checkRefund(1L, 2L);
+                .checkRefund(1L, sessionUser.getId());
 
         mockMvc.perform(
                         patch("/rent/histories/refund/{historyId}", 1L)
@@ -397,9 +399,10 @@ public class RentControllerTest extends RestDocsSupport {
 
         // given
         MockHttpSession mockHttpSession = new MockHttpSession();
-        mockHttpSession.setAttribute("userId", 2L);
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        mockHttpSession.setAttribute("user", sessionUser);
         doNothing().when(rentService)
-                .checkPayment(1L, 2L);
+                .checkPayment(1L, sessionUser.getId());
 
         mockMvc.perform(
                         patch("/rent/histories/payment/{historyId}", 1L)

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -70,7 +70,7 @@ public class UserControllerTest extends RestDocsSupport {
         User user = FixtureBuilderFactory.builderUser().sample();
 
         session.setAttribute("user", sessionUser);
-        given(userService.findUserById(anyLong()))
+        given(userService.findDecryptedUserById(anyLong()))
                 .willReturn(user);
 
         // when & then

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -487,7 +487,8 @@ public class UserControllerTest extends RestDocsSupport {
     void deleteUserTest() throws Exception {
         // given
         MockHttpSession mockHttpSession = new MockHttpSession();
-        mockHttpSession.setAttribute("userId", 70L);
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        mockHttpSession.setAttribute("user", sessionUser);
 
         // when
 

--- a/src/test/java/upbrella/be/user/service/UserServiceDynamicTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceDynamicTest.java
@@ -53,7 +53,7 @@ class UserServiceDynamicTest {
 
         return List.of(
                 DynamicTest.dynamicTest("새로 가입한 유저는 DB에 저장된다.", () -> {
-                    SessionUser joined = userService.join(user.getSocialId().hashCode(), joinRequest);
+                    SessionUser joined = userService.join((long) user.getSocialId().hashCode(), joinRequest);
                     Optional<User> foundUser = userRepository.findById(joined.getId());
 
                     assertAll(() -> assertTrue(foundUser.isPresent()),


### PR DESCRIPTION
## 🟢 구현내용
- #207 

## 🧩 고민과 해결과정
- 세션 로직 userId -> user 변경했습니다.
- 객체에서 decrypt를 실행해서 DB에 암호화된 데이터가 flush되는 문제를 고치기 위해 find 메소드들을 상태 수정용(patch), deep copy(get용) 메소드로 분리했습니다.