### PR TITLE
[feat] 사용자 계좌 삭제 구현 (#213)

### DIFF
--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -81,6 +81,9 @@ include::{snippets}/user-history-doc/response-fields-data.adoc[]
 include::{snippets}/update-user-bank-account-doc/http-request.adoc[]
 include::{snippets}/update-user-bank-account-doc/request-fields.adoc[]
 
+=== 사용자 은행 정보 삭제
+include::{snippets}/delete-user-bank-account-doc/http-request.adoc[]
+
 === 사용자 회원 탈퇴
 include::{snippets}/delete-user-doc/http-request.adoc[]
 

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -179,6 +179,22 @@ public class UserController {
                 ));
     }
 
+    @DeleteMapping("/bankAccount")
+    public ResponseEntity<CustomResponse> deleteUserBankAccount(HttpSession session) {
+
+        SessionUser sessionUser = (SessionUser) session.getAttribute("user");
+
+        userService.deleteUserBankAccount(sessionUser.getId());
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "사용자 계좌 정보 삭제 성공"
+                ));
+    }
+
     @DeleteMapping("/loggedIn")
     public ResponseEntity<CustomResponse> deleteUser(HttpSession session) {
 

--- a/src/main/java/upbrella/be/user/entity/User.java
+++ b/src/main/java/upbrella/be/user/entity/User.java
@@ -78,4 +78,11 @@ public class User {
                 .accountNumber(AesEncryptor.decrypt(this.accountNumber))
                 .build();
     }
+
+    public void deleteBankAccount() {
+
+        this.bank = null;
+        this.accountNumber = null;
+    }
+
 }

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -114,4 +114,11 @@ public class UserService {
                 .decryptData();
     }
 
+    public void deleteUserBankAccount(Long id) {
+
+        User foundUser = findUserById(id);
+
+        foundUser.deleteBankAccount();
+    }
+
 }

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
@@ -539,7 +540,7 @@ public class UserControllerTest extends RestDocsSupport {
         mockHttpSession.setAttribute("user", sessionUser);
 
         // when
-
+        doNothing().when(userService).deleteUserBankAccount(sessionUser.getId());
 
         // then
         mockMvc.perform(

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -529,4 +529,28 @@ public class UserControllerTest extends RestDocsSupport {
                         )));
 
     }
+
+    @Test
+    @DisplayName("사용자는 자신의 계좌정보를 삭제할 수 있다.")
+    void deleteBackAccountTest() throws Exception {
+        // given
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        MockHttpSession mockHttpSession = new MockHttpSession();
+        mockHttpSession.setAttribute("user", sessionUser);
+
+        // when
+
+
+        // then
+        mockMvc.perform(
+                        delete("/users/bankAccount")
+                                .session(mockHttpSession)
+                ).andExpect(status().isOk())
+                .andDo(print())
+                .andDo(document("delete-user-bank-account-doc",
+                                getDocumentRequest(),
+                                getDocumentResponse()
+                        )
+                );
+    }
 }

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -356,4 +356,21 @@ class UserServiceTest {
         assertThatThrownBy(() -> userService.join(blackList, joinRequest))
                 .isInstanceOf(BlackListUserException.class);
     }
+
+    @Test
+    @DisplayName("사용자는 계좌 정보를 삭제할 수 있다.")
+    void deleteUserBankAccountTest() {
+        // given
+        User user = FixtureBuilderFactory.builderUser().sample();
+        given(userRepository.findById(user.getId())).willReturn(Optional.of(user));
+
+        // when
+        userService.deleteUser(user.getId());
+
+        // then
+        assertAll(
+                () -> assertThat(user.getBank()).isNull(),
+                () -> assertThat(user.getAccountNumber()).isNull()
+        );
+    }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #213 

## 🧩 고민과 해결과정
- 사용자 계좌 삭제를 수정에서 한번에 처리할까 하였지만, 사용자가 임의로 공백을 넣을 경우를 고려하여 새로운 api를 생성하였습니다. 