### PR TITLE
[feat] 보증금 환급된 대여 기록의 계좌 정보를 삭제할 수 있다.(#216)

### DIFF
--- a/src/docs/asciidoc/api/rent/rent.adoc
+++ b/src/docs/asciidoc/api/rent/rent.adoc
@@ -62,3 +62,8 @@ include::{snippets}/refund-rent-doc/path-parameters.adoc[]
 
 include::{snippets}/check-payment-doc/http-request.adoc[]
 include::{snippets}/check-payment-doc/path-parameters.adoc[]
+
+=== 보증금 환급한 대여 기록 계좌 정보 삭제
+==== HTTP Request
+include::{snippets}/delete-rent-account-doc/http-request.adoc[]
+include::{snippets}/delete-rent-account-doc/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -159,4 +159,19 @@ public class RentController {
                         "입금 확인 성공"
                 ));
     }
+
+    // TODO : admin uri로 수정
+    @DeleteMapping("/histories/{historyId}/account")
+    public ResponseEntity<CustomResponse> deleteBankAccount(@PathVariable long historyId) {
+
+        rentService.deleteBankAccount(historyId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse(
+                        "success",
+                        200,
+                        "대여 기록의 계좌 삭제 성공"
+                ));
+    }
 }

--- a/src/main/java/upbrella/be/rent/entity/History.java
+++ b/src/main/java/upbrella/be/rent/entity/History.java
@@ -2,6 +2,7 @@ package upbrella.be.rent.entity;
 
 import lombok.*;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;
+import upbrella.be.rent.exception.NotReturnedException;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.response.SingleHistoryResponse;
@@ -56,8 +57,8 @@ public class History {
 
     public void refund(User user, LocalDateTime refundedAt) {
 
-            this.refundedAt = refundedAt;
-            this.refundedBy = user;
+        this.refundedAt = refundedAt;
+        this.refundedBy = user;
     }
 
     public void paid(User user, LocalDateTime paidAt) {
@@ -116,5 +117,14 @@ public class History {
                 .isReturned(isReturned)
                 .isRefunded(isRefunded)
                 .build();
+    }
+
+    public void deleteBankAccount() {
+
+        if (this.returnedAt == null) {
+            throw new NotReturnedException("[ERROR] 우산 반납이 완료되지 않았습니다.");
+        }
+        this.bank = null;
+        this.accountNumber = null;
     }
 }

--- a/src/main/java/upbrella/be/rent/entity/History.java
+++ b/src/main/java/upbrella/be/rent/entity/History.java
@@ -121,7 +121,7 @@ public class History {
 
     public void deleteBankAccount() {
 
-        if (this.paidAt == null) {
+        if (this.refundedAt == null) {
             throw new NotRefundedException("[ERROR] 보증금 환급이 완료되지 않았습니다.");
         }
         this.bank = null;

--- a/src/main/java/upbrella/be/rent/entity/History.java
+++ b/src/main/java/upbrella/be/rent/entity/History.java
@@ -2,7 +2,7 @@ package upbrella.be.rent.entity;
 
 import lombok.*;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;
-import upbrella.be.rent.exception.NotReturnedException;
+import upbrella.be.rent.exception.NotRefundedException;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.response.SingleHistoryResponse;
@@ -121,8 +121,8 @@ public class History {
 
     public void deleteBankAccount() {
 
-        if (this.returnedAt == null) {
-            throw new NotReturnedException("[ERROR] 우산 반납이 완료되지 않았습니다.");
+        if (this.paidAt == null) {
+            throw new NotRefundedException("[ERROR] 보증금 환급이 완료되지 않았습니다.");
         }
         this.bank = null;
         this.accountNumber = null;

--- a/src/main/java/upbrella/be/rent/exception/NotRefundedException.java
+++ b/src/main/java/upbrella/be/rent/exception/NotRefundedException.java
@@ -1,0 +1,9 @@
+package upbrella.be.rent.exception;
+
+public class NotRefundedException extends RuntimeException{
+
+    public NotRefundedException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/rent/exception/NotReturnedException.java
+++ b/src/main/java/upbrella/be/rent/exception/NotReturnedException.java
@@ -1,9 +1,0 @@
-package upbrella.be.rent.exception;
-
-public class NotReturnedException extends RuntimeException{
-
-    public NotReturnedException(String message) {
-
-        super(message);
-    }
-}

--- a/src/main/java/upbrella/be/rent/exception/NotReturnedException.java
+++ b/src/main/java/upbrella/be/rent/exception/NotReturnedException.java
@@ -1,0 +1,9 @@
+package upbrella.be.rent.exception;
+
+public class NotReturnedException extends RuntimeException{
+
+    public NotReturnedException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -212,4 +212,11 @@ public class RentService {
         return rentRepository.findByUserIdAndReturnedAtIsNull(sessionUser.getId())
                 .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
     }
+
+    public void deleteBankAccount(long historyId) {
+
+        History history = findHistoryById(historyId);
+
+        history.deleteBankAccount();
+    }
 }

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -213,6 +213,7 @@ public class RentService {
                 .orElseThrow(() -> new NonExistingBorrowedHistoryException("[ERROR] 사용자가 빌린 우산이 없습니다."));
     }
 
+    @Transactional
     public void deleteBankAccount(long historyId) {
 
         History history = findHistoryById(historyId);

--- a/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
+++ b/src/test/java/upbrella/be/rent/controller/RentControllerTest.java
@@ -418,4 +418,27 @@ public class RentControllerTest extends RestDocsSupport {
                         )));
 
     }
+
+    @Test
+    @DisplayName("대여 기록의 계좌 삭제 성공 테스트")
+    void deleteRentAccountTest() throws Exception {
+        // given
+        long historyId = 1L;
+
+        // when
+        doNothing().when(rentService).deleteBankAccount(historyId);
+
+        // then
+        mockMvc.perform(
+                        delete("/rent/histories/{historyId}/account", historyId)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("delete-rent-account-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("historyId")
+                                        .description("대여 기록 고유번호")
+                        )));
+    }
 }

--- a/src/test/java/upbrella/be/rent/service/RentServiceTest.java
+++ b/src/test/java/upbrella/be/rent/service/RentServiceTest.java
@@ -18,6 +18,7 @@ import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
 import upbrella.be.rent.dto.response.RentalHistoryResponse;
 import upbrella.be.rent.entity.History;
 import upbrella.be.rent.exception.NonExistingHistoryException;
+import upbrella.be.rent.exception.NotRefundedException;
 import upbrella.be.rent.repository.RentRepository;
 import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.service.StoreMetaService;
@@ -496,5 +497,35 @@ class RentServiceTest {
                     () -> then(rentRepository).should(times(1))
                             .findByUserIdAndReturnedAtIsNull(sessionUser.getId()));
         }
+    }
+
+    @Test
+    @DisplayName("대여 기록의 계좌 삭제 성공")
+    void deleteRentAccount() {
+        // given
+        History history = FixtureBuilderFactory.builderHistory().sample();
+
+        // when
+        history.deleteBankAccount();
+
+        // then
+        assertAll(
+                () -> assertThat(history.getBank()).isNull(),
+                () -> assertThat(history.getAccountNumber()).isNull()
+        );
+    }
+
+    @Test
+    @DisplayName("반납되지 않은 대여 기록의 계좌 삭제 실패")
+    void deleteRentAccountThrowTest() {
+        // given
+        History history = FixtureBuilderFactory.builderHistory()
+                .set("refundedAt", null)
+                .sample();
+        // when
+
+        // then
+        assertThatThrownBy(history::deleteBankAccount)
+                .isInstanceOf(NotRefundedException.class);
     }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #216 

## 🧩 고민과 해결과정
- refundedAt 이 null 인 경우 예외가 발생하도록 처리하였습니다. 