### PR TITLE
[feat] User API 기능 추가 (이메일, 관리자 변경) #228

### DIFF
--- a/src/docs/asciidoc/api/admin/user.adoc
+++ b/src/docs/asciidoc/api/admin/user.adoc
@@ -26,3 +26,6 @@ include::{snippets}/find-all-black-list-doc/response-fields-data.adoc[]
 include::{snippets}/delete-black-list-doc/http-request.adoc[]
 include::{snippets}/delete-black-list-doc/path-parameters.adoc[]
 
+=== 사용자 관리자 권한 수정
+include::{snippets}/update-admin-status-doc/http-request.adoc[]
+include::{snippets}/update-admin-status-doc/path-parameters.adoc[]

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -72,3 +72,7 @@ include::{snippets}/delete-user-bank-account-doc/http-request.adoc[]
 
 === 사용자 회원 탈퇴
 include::{snippets}/delete-user-doc/http-request.adoc[]
+
+=== 사용자 관리자 권한 수정
+include::{snippets}/update-admin-status-doc/http-request.adoc[]
+include::{snippets}/update-admin-status-doc/path-parameters.adoc[]

--- a/src/docs/asciidoc/api/user/user.adoc
+++ b/src/docs/asciidoc/api/user/user.adoc
@@ -72,7 +72,3 @@ include::{snippets}/delete-user-bank-account-doc/http-request.adoc[]
 
 === 사용자 회원 탈퇴
 include::{snippets}/delete-user-doc/http-request.adoc[]
-
-=== 사용자 관리자 권한 수정
-include::{snippets}/update-admin-status-doc/http-request.adoc[]
-include::{snippets}/update-admin-status-doc/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -208,6 +208,7 @@ public class UserController {
                         "사용자 탈퇴 성공"
                 ));
     }
+
     @DeleteMapping("/admin/users/{userId}")
     public ResponseEntity<CustomResponse> withdrawUser(HttpSession session, @PathVariable long userId) {
 
@@ -265,6 +266,20 @@ public class UserController {
                         "success",
                         200,
                         "블랙리스트 삭제 성공"
+                ));
+    }
+
+    @PatchMapping("/admin/users/{userId}")
+    public ResponseEntity<CustomResponse> updateAdminStatus(@PathVariable long userId) {
+
+        userService.updateAdminStatus(userId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "관리자 권한 변경 성공"
                 ));
     }
 }

--- a/src/main/java/upbrella/be/user/dto/request/JoinRequest.java
+++ b/src/main/java/upbrella/be/user/dto/request/JoinRequest.java
@@ -10,6 +10,7 @@ public class JoinRequest {
 
     private String name;
     private String phoneNumber;
+    private String email;
     private String bank;
     private String accountNumber;
 }

--- a/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
@@ -12,6 +12,7 @@ public class SingleUserInfoResponse {
     private long socialId;
     private String name;
     private String phoneNumber;
+    private String email;
     private String bank;
     private String accountNumber;
     private boolean adminStatus;
@@ -23,6 +24,7 @@ public class SingleUserInfoResponse {
                 .socialId(user.getSocialId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
+                .email(user.getEmail())
                 .bank(user.getBank())
                 .accountNumber(user.getAccountNumber())
                 .adminStatus(user.isAdminStatus())

--- a/src/main/java/upbrella/be/user/entity/User.java
+++ b/src/main/java/upbrella/be/user/entity/User.java
@@ -85,4 +85,8 @@ public class User {
         this.accountNumber = null;
     }
 
+    public void updateAdminStatus() {
+
+        this.adminStatus = !this.adminStatus;
+    }
 }

--- a/src/main/java/upbrella/be/user/entity/User.java
+++ b/src/main/java/upbrella/be/user/entity/User.java
@@ -24,6 +24,7 @@ public class User {
     private Long socialId;
     private String name;
     private String phoneNumber;
+    private String email;
     private boolean adminStatus;
     private String bank;
     private String accountNumber;
@@ -34,6 +35,7 @@ public class User {
                 .socialId((long) socialId.hashCode())
                 .name(joinRequest.getName())
                 .phoneNumber(joinRequest.getPhoneNumber())
+                .email(joinRequest.getEmail())
                 .adminStatus(false)
                 .bank(AesEncryptor.encrypt(joinRequest.getBank()))
                 .accountNumber(AesEncryptor.encrypt(joinRequest.getAccountNumber()))
@@ -61,6 +63,7 @@ public class User {
         this.socialId = 0L;
         this.name = "정지된 회원";
         this.phoneNumber = "deleted";
+        this.email = "deleted";
         this.adminStatus = false;
         this.bank = null;
         this.accountNumber = null;
@@ -74,6 +77,7 @@ public class User {
                 .name(this.name)
                 .phoneNumber(this.phoneNumber)
                 .adminStatus(this.adminStatus)
+                .email(this.email)
                 .bank(AesEncryptor.decrypt(this.bank))
                 .accountNumber(AesEncryptor.decrypt(this.accountNumber))
                 .build();

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -24,15 +24,16 @@ import java.util.stream.Collectors;
 
 @Service
 public class UserService {
+
+    private final UserRepository userRepository;
+    private final BlackListRepository blackListRepository;
+    private final RentService rentService;
+
     public UserService(UserRepository userRepository, BlackListRepository blackListRepository, @Lazy RentService rentService) {
         this.userRepository = userRepository;
         this.blackListRepository = blackListRepository;
         this.rentService = rentService;
     }
-
-    private final UserRepository userRepository;
-    private final BlackListRepository blackListRepository;
-    private final RentService rentService;
 
     public SessionUser login(Long socialId) {
 

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -136,4 +136,12 @@ public class UserService {
 
         blackListRepository.deleteById(blackListId);
     }
+
+    @Transactional
+    public void updateAdminStatus(Long id) {
+
+        User foundUser = findUserById(id);
+
+        foundUser.updateAdminStatus();
+    }
 }

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -135,6 +135,7 @@ public class FixtureBuilderFactory {
                 .set("socialId", buildLong(100000000))
                 .set("name", pickRandomString(nameList))
                 .set("phoneNumber", pickPhoneNumberString())
+                .set("email", "email@email.com")
                 .set("bank", AesEncryptor.encrypt(pickRandomString(bankList)))
                 .set("accountNumber", AesEncryptor.encrypt(pickAccountNumberString()));
     }

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -305,6 +305,8 @@ public class UserControllerTest extends RestDocsSupport {
                                             .description("이름"),
                                     fieldWithPath("phoneNumber")
                                             .description("연락처"),
+                                    fieldWithPath("email")
+                                            .description("이메일"),
                                     fieldWithPath("bank")
                                             .optional()
                                             .description("은행"),
@@ -418,6 +420,8 @@ public class UserControllerTest extends RestDocsSupport {
                                         .description("사용자 이름"),
                                 fieldWithPath("users[].phoneNumber").type(JsonFieldType.STRING)
                                         .description("사용자 전화번호"),
+                                fieldWithPath("users[].email").type(JsonFieldType.STRING)
+                                        .description("사용자 이메일"),
                                 fieldWithPath("users[].bank").type(JsonFieldType.STRING)
                                         .optional()
                                         .description("은행 이름"),

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -138,7 +138,7 @@ public class UserControllerTest extends RestDocsSupport {
 
         @BeforeEach
         void setUp() {
-            code = LoginCodeRequest.builder().code("1kdfjq0243f").build();;
+            code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
             oauthToken = FixtureFactory.buildOauthToken();
             kakaoLoginResponse = FixtureFactory.buildKakaoLoginResponse();
         }
@@ -596,8 +596,8 @@ public class UserControllerTest extends RestDocsSupport {
 
         // then
         mockMvc.perform(
-                get("/users/blackList")
-        ).andDo(print())
+                        get("/users/blackList")
+                ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("find-all-black-list-doc",
                         getDocumentRequest(),
@@ -626,8 +626,8 @@ public class UserControllerTest extends RestDocsSupport {
 
         // then
         mockMvc.perform(
-                delete("/users/blackList/{blackListId}", blackListId)
-        ).andDo(print())
+                        delete("/users/blackList/{blackListId}", blackListId)
+                ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("delete-black-list-doc",
                         getDocumentRequest(),
@@ -636,5 +636,27 @@ public class UserControllerTest extends RestDocsSupport {
                                 parameterWithName("blackListId").description("블랙리스트 고유번호")
                         )));
 
+    }
+
+    @Test
+    @DisplayName("관리자가 회원의 관리자 상태를 변경할 수 있다.")
+    void updateAdminStatusTest() throws Exception {
+        // given
+        long userId = 1L;
+        doNothing().when(userService).updateAdminStatus(userId);
+
+        // when
+
+        // then
+        mockMvc.perform(
+                        patch("/admin/users/{userId}", userId)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("update-admin-status-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("userId").description("회원 고유번호")
+                        )));
     }
 }

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -405,4 +405,21 @@ class UserServiceTest {
         // then
         verify(blackListRepository, times(1)).deleteById(blackListId);
     }
+
+    @Test
+    @DisplayName("사용자는 관리자 권한을 변경할 수 있다.")
+    void updateAdminStatusTest() {
+        // given
+        User user = FixtureBuilderFactory.builderUser()
+                .set("adminStatus", false)
+                .sample();
+
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when
+        userService.updateAdminStatus(1L);
+
+        // then
+        assertThat(user.isAdminStatus()).isTrue();
+    }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #226 
- #227 

## 🧩 고민과 해결과정
- amdinStatus 의 경우 api를 두 개 만들까 고민했지만, 단순 로직이기 때문에, true일 경우 false, false일 경우 true로 변경되도록 로직을 설계하였습니다. 
