### PR TITLE
[fix] 협업지점 목록 소분류 별 그룹화, 협업지점 상세 누락 필드 추가 (#230, #231)

### DIFF
--- a/src/main/java/upbrella/be/store/dto/response/AllStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/AllStoreIntroductionResponse.java
@@ -9,12 +9,13 @@ import java.util.List;
 @Builder
 public class AllStoreIntroductionResponse {
 
-    private List<SingleStoreIntroductionResponse> stores;
 
-    public static AllStoreIntroductionResponse of(List<SingleStoreIntroductionResponse> stores) {
+    private List<StoreIntroductionsResponseByClassification> storesByClassification;
+
+    public static AllStoreIntroductionResponse of(List<StoreIntroductionsResponseByClassification> storesByClassification) {
 
         return AllStoreIntroductionResponse.builder()
-                .stores(stores)
+                .storesByClassification(storesByClassification)
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
@@ -2,6 +2,11 @@ package upbrella.be.store.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
+import upbrella.be.store.entity.StoreDetail;
+import upbrella.be.store.entity.StoreMeta;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -20,5 +25,24 @@ public class SingleStoreIntroductionResponse {
                 .name(name)
                 .category(category)
                 .build();
+    }
+    public static SingleStoreIntroductionResponse createSingleIntroduction(StoreDetail storeDetail) {
+
+        List<SingleImageUrlResponse> sortedImageUrls = storeDetail.getSortedStoreImages().stream()
+                .map(SingleImageUrlResponse::createImageUrlResponse)
+                .collect(Collectors.toList());
+
+        String thumbnail = createThumbnail(sortedImageUrls);
+        StoreMeta storeMeta = storeDetail.getStoreMeta();
+
+        return of(storeDetail.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
+    }
+
+    private static String createThumbnail(List<SingleImageUrlResponse> imageUrls) {
+
+        return imageUrls.stream()
+                .findFirst()
+                .map(SingleImageUrlResponse::getImageUrl)
+                .orElse(null);
     }
 }

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
@@ -1,9 +1,7 @@
 package upbrella.be.store.dto.response;
 
-import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;
 import lombok.Getter;
-import upbrella.be.store.entity.StoreDetail;
 
 @Getter
 @Builder

--- a/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
@@ -15,11 +15,15 @@ public class StoreFindByIdResponse {
 
     private long id;
     private String name;
-    private String businessHours;
-    private String contactNumber;
-    private String address;
+    private String category;
     private long availableUmbrellaCount;
     private boolean openStatus;
+    private String businessHours;
+    private String contactNumber;
+    private String instaUrl;
+    private String address;
+    private String umbrellaLocation;
+    private String description;
     private double latitude;
     private double longitude;
     private List<String> imageUrls;
@@ -32,6 +36,10 @@ public class StoreFindByIdResponse {
                 .businessHours(storeDetail.getWorkingHour())
                 .contactNumber(storeDetail.getContactInfo())
                 .address(storeDetail.getAddress())
+                .instaUrl(storeDetail.getInstaUrl())
+                .description(storeDetail.getContent())
+                .category(storeDetail.getStoreMeta().getCategory())
+                .umbrellaLocation(storeDetail.getUmbrellaLocation())
                 .availableUmbrellaCount(availableUmbrellaCount)
                 .openStatus(storeDetail.getStoreMeta().isOpenStore(LocalDateTime.now())) // 의사 결정 전까지 임시로 True 고정
                 .latitude(storeDetail.getStoreMeta().getLatitude())

--- a/src/main/java/upbrella/be/store/dto/response/StoreIntroductionsResponseByClassification.java
+++ b/src/main/java/upbrella/be/store/dto/response/StoreIntroductionsResponseByClassification.java
@@ -1,0 +1,26 @@
+package upbrella.be.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import upbrella.be.store.entity.StoreDetail;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Builder
+public class StoreIntroductionsResponseByClassification {
+
+    private long subClassificationId;
+    private List<SingleStoreIntroductionResponse> stores;
+
+    public static StoreIntroductionsResponseByClassification of(long subClassificationId, List<StoreDetail> storeDetails) {
+
+        return StoreIntroductionsResponseByClassification.builder()
+                .subClassificationId(subClassificationId)
+                .stores(storeDetails.stream()
+                                .map(SingleStoreIntroductionResponse::createSingleIntroduction)
+                                .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryCustom.java
+++ b/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryCustom.java
@@ -1,6 +1,5 @@
 package upbrella.be.store.repository;
 
-import upbrella.be.store.dto.response.SingleStoreResponse;
 import upbrella.be.store.entity.StoreDetail;
 
 import java.util.List;

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -90,16 +90,11 @@ public class StoreDetailService {
         List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
 
         Map<Long, List<StoreDetail>> collected = storeDetails.stream()
-                .sorted(new Comparator<StoreDetail>() {
-                    @Override
-                    public int compare(StoreDetail o1, StoreDetail o2) {
-                        return (int) (o1.getStoreMeta().getSubClassification().getId() - o2.getStoreMeta().getSubClassification().getId());
-                    }
-                })
                 .collect(Collectors.groupingBy(storeDetail -> storeDetail.getStoreMeta().getSubClassification().getId()));
 
         //같은 ID끼리 리스트로 모은 것을 StoreIntroductionsResponseByClassification으로 변환
         List<StoreIntroductionsResponseByClassification> storeDetailsByClassification = collected.entrySet().stream()
+                .sorted(Comparator.comparingLong(Map.Entry::getKey))
                 .map(entry -> StoreIntroductionsResponseByClassification.of(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
 

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -13,9 +13,7 @@ import upbrella.be.store.exception.NonExistingStoreDetailException;
 import upbrella.be.store.repository.StoreDetailRepository;
 import upbrella.be.umbrella.service.UmbrellaService;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 
 @Service
@@ -89,28 +87,27 @@ public class StoreDetailService {
 
     public AllStoreIntroductionResponse findAllStoreIntroductions() {
 
-        List<StoreDetail> storeIntroductions = storeDetailRepository.findAllStores();
+        List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
 
-        List<SingleStoreIntroductionResponse> collect = storeIntroductions.stream()
-                .map(this::createSingleIntroduction)
+        Map<Long, List<StoreDetail>> collected = storeDetails.stream()
+                .sorted(new Comparator<StoreDetail>() {
+                    @Override
+                    public int compare(StoreDetail o1, StoreDetail o2) {
+                        return (int) (o1.getStoreMeta().getSubClassification().getId() - o2.getStoreMeta().getSubClassification().getId());
+                    }
+                })
+                .collect(Collectors.groupingBy(storeDetail -> storeDetail.getStoreMeta().getSubClassification().getId()));
+
+        //같은 ID끼리 리스트로 모은 것을 StoreIntroductionsResponseByClassification으로 변환
+        List<StoreIntroductionsResponseByClassification> storeDetailsByClassification = collected.entrySet().stream()
+                .map(entry -> StoreIntroductionsResponseByClassification.of(entry.getKey(), entry.getValue()))
                 .collect(Collectors.toList());
 
-        return AllStoreIntroductionResponse.of(collect);
+        return AllStoreIntroductionResponse.of(storeDetailsByClassification);
     }
 
     public void saveStoreDetail(StoreDetail storeDetail) {
 
         storeDetailRepository.save(storeDetail);
-    }
-
-    private SingleStoreIntroductionResponse createSingleIntroduction(StoreDetail storeDetail) {
-
-        List<SingleImageUrlResponse> sortedImageUrls = storeDetail.getSortedStoreImages().stream()
-                .map(SingleImageUrlResponse::createImageUrlResponse)
-                .collect(Collectors.toList());
-
-        String thumbnail = storeImageService.createThumbnail(sortedImageUrls);
-        StoreMeta storeMeta = storeDetail.getStoreMeta();
-        return SingleStoreIntroductionResponse.of(storeDetail.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -858,23 +858,21 @@ class StoreControllerTest extends RestDocsSupport {
     @Test
     @DisplayName("사용자는 협업지점 소개 페이지를 조회할 수 있다.")
     void findStoreIntroductionTest() throws Exception {
+
         // given
-        SingleStoreIntroductionResponse store = SingleStoreIntroductionResponse.builder()
-                .id(1L)
-                .name("가게 이름")
-                .category("가게 카테고리")
-                .thumbnail("가게 썸네일")
+        StoreIntroductionsResponseByClassification storeIntroductionsResponseByClassification = StoreIntroductionsResponseByClassification
+                .builder()
+                .subClassificationId(1)
+                .stores(List.of(SingleStoreIntroductionResponse.of(1L, "가게 이름", "가게 카테고리", "가게 썸네일")))
                 .build();
+
         AllStoreIntroductionResponse response = AllStoreIntroductionResponse.builder()
-                .stores(List.of(store))
+                .storesByClassification(List.of(storeIntroductionsResponseByClassification))
                 .build();
 
         given(storeDetailService.findAllStoreIntroductions()).willReturn(response);
 
-        // when
-
-
-        // then
+        // when & then
         mockMvc.perform(
                         get("/stores/introductions")
                 ).andDo(print())
@@ -884,15 +882,19 @@ class StoreControllerTest extends RestDocsSupport {
                         getDocumentResponse(),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
-                                fieldWithPath("stores[]").type(JsonFieldType.ARRAY)
-                                        .description("가게 소개 목록"),
-                                fieldWithPath("stores[].id").type(JsonFieldType.NUMBER)
+                                fieldWithPath("storesByClassification[]").type(JsonFieldType.ARRAY)
+                                        .description("전체 협업 지점 소개 목록"),
+                                fieldWithPath("storesByClassification[].subClassificationId").type(JsonFieldType.NUMBER)
+                                        .description("협업 지점 소분류 고유번호"),
+                                fieldWithPath("storesByClassification[].stores[]").type(JsonFieldType.ARRAY)
+                                        .description("소분류별 협업 지점 목록"),
+                                fieldWithPath("storesByClassification[].stores[].id").type(JsonFieldType.NUMBER)
                                         .description("가게 고유번호"),
-                                fieldWithPath("stores[].name").type(JsonFieldType.STRING)
+                                fieldWithPath("storesByClassification[].stores[].name").type(JsonFieldType.STRING)
                                         .description("가게 이름"),
-                                fieldWithPath("stores[].category").type(JsonFieldType.STRING)
+                                fieldWithPath("storesByClassification[].stores[].category").type(JsonFieldType.STRING)
                                         .description("가게 카테고리"),
-                                fieldWithPath("stores[].thumbnail").type(JsonFieldType.STRING)
+                                fieldWithPath("storesByClassification[].stores[].thumbnail").type(JsonFieldType.STRING)
                                         .description("가게 썸네일")
                         )));
     }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -36,6 +36,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentRequest;
 import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentResponse;
 
+//1hour
 @ExtendWith(MockitoExtension.class)
 class StoreControllerTest extends RestDocsSupport {
     @Mock
@@ -60,9 +61,13 @@ class StoreControllerTest extends RestDocsSupport {
         StoreFindByIdResponse storeFindByIdResponse = StoreFindByIdResponse.builder()
                 .id(1)
                 .name("업브렐라")
+                .category("카페")
+                .umbrellaLocation("가게 앞")
+                .instaUrl("인스타 ID 예시")
                 .businessHours("09:00 ~ 18:00")
                 .contactNumber("010-0000-0000")
                 .address("서울특별시 강남구 테헤란로 427")
+                .description("우리 카페는 맛있고 뷰가 좋습니다.")
                 .availableUmbrellaCount(10)
                 .openStatus(true)
                 .latitude(37.503716)
@@ -93,16 +98,24 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("협업 지점 고유번호"),
                                 fieldWithPath("name").type(JsonFieldType.STRING)
                                         .description("이름"),
-                                fieldWithPath("businessHours").type(JsonFieldType.STRING)
-                                        .description("영업 시간"),
-                                fieldWithPath("contactNumber").type(JsonFieldType.STRING)
-                                        .description("연락처"),
-                                fieldWithPath("address").type(JsonFieldType.STRING)
-                                        .description("주소"),
+                                fieldWithPath("category").type(JsonFieldType.STRING)
+                                        .description("카테고리"),
                                 fieldWithPath("availableUmbrellaCount").type(JsonFieldType.NUMBER)
                                         .description("사용가능한 우산 개수"),
                                 fieldWithPath("openStatus").type(JsonFieldType.BOOLEAN)
                                         .description("오픈 여부"),
+                                fieldWithPath("businessHours").type(JsonFieldType.STRING)
+                                        .description("영업 시간"),
+                                fieldWithPath("contactNumber").type(JsonFieldType.STRING)
+                                        .description("연락처"),
+                                fieldWithPath("instaUrl").type(JsonFieldType.STRING)
+                                        .description("인스타그램 URL"),
+                                fieldWithPath("address").type(JsonFieldType.STRING)
+                                        .description("주소"),
+                                fieldWithPath("umbrellaLocation").type(JsonFieldType.STRING)
+                                        .description("우산 위치"),
+                                fieldWithPath("description").type(JsonFieldType.STRING)
+                                        .description("소개 글"),
                                 fieldWithPath("latitude").type(JsonFieldType.NUMBER)
                                         .description("위도"),
                                 fieldWithPath("longitude").type(JsonFieldType.NUMBER)

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -631,6 +631,7 @@ public class StoreDetailServiceTest {
                 .activated(true)
                 .deleted(false)
                 .category("카페, 디저트")
+                .subClassification(Classification.builder().id(1L).name("카페, 디저").type(ClassificationType.SUB_CLASSIFICATION).build())
                 .build();
 
         StoreDetail storeDetail = StoreDetail.builder()
@@ -642,19 +643,29 @@ public class StoreDetailServiceTest {
                 .instaUrl("모티브 인서타")
                 .workingHour("매일 7시 ~ 12시")
                 .umbrellaLocation("문 앞")
-                .storeImages(Set.of())
+                .storeImages(Set.of(StoreImage.builder().imageUrl("가게 썸네일").build()))
+                .build();
+
+        StoreIntroductionsResponseByClassification storeIntroductionsResponseByClassification = StoreIntroductionsResponseByClassification
+                .builder()
+                .subClassificationId(1)
+                .stores(List.of(SingleStoreIntroductionResponse.of(2L, "가게 썸네일", "스타벅스", "카페, 디저트")))
+                .build();
+
+        AllStoreIntroductionResponse expected = AllStoreIntroductionResponse.builder()
+                .storesByClassification(List.of(storeIntroductionsResponseByClassification))
                 .build();
 
         given(storeDetailRepository.findAllStores()).willReturn(List.of(storeDetail));
 
         // when
         AllStoreIntroductionResponse response = storeDetailService.findAllStoreIntroductions();
-        SingleStoreIntroductionResponse stores = response.getStores().get(0);
+
         // then
         assertAll(
-                () -> assertThat(stores.getId()).isEqualTo(storeDetail.getId()),
-                () -> assertThat(stores.getName()).isEqualTo(storeDetail.getStoreMeta().getName()),
-                () -> assertThat(stores.getCategory()).isEqualTo(storeDetail.getStoreMeta().getCategory())
+                () -> assertThat(response)
+                        .usingRecursiveComparison()
+                        .isEqualTo(expected)
         );
     }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #230 
- #231 

## 🧩 고민과 해결과정
소분류별로 오름차순 정렬 한 후 그룹화되어 반환하도록 API 수정했습니다. thumbnail 선정 로직을 단순히 첫번째 이미지를 고르는 로직이라 DTO단으로 옮겼습니다. 