### PR TITLE
[feat] 협업지점 활성화/비활성화 api 분리 (#240)

### DIFF
--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -87,3 +87,13 @@ include::{snippets}/store-find-all-sub-classification-doc/response-fields-data.a
 ==== HTTP Request
 include::{snippets}/store-delete-sub-classification-doc/http-request.adoc[]
 include::{snippets}/store-delete-sub-classification-doc/path-parameters.adoc[]
+
+=== 협업지점 활성화
+
+==== HTTP Request
+include::{snippets}/store-update-activate-status-doc/http-request.adoc[]
+include::{snippets}/store-update-activate-status-doc/path-parameters.adoc[]
+
+=== 협업지점 비활성화
+include::{snippets}/store-update-inactivate-status-doc/http-request.adoc[]
+include::{snippets}/store-update-inactivate-status-doc/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -244,4 +244,18 @@ public class StoreController {
                         "협업지점 메타 전체 조회 성공",
                         storeDetailService.findAllStoreIntroductions()));
     }
+
+    @PatchMapping("/admin/stores/{storeId}/activateStatus")
+    public ResponseEntity<CustomResponse> updateStoreActivateStatus(@PathVariable long storeId) {
+
+        storeMetaService.updateStoreActivateStatus(storeId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "협업지점 활성화 상태 변경 성공"
+                ));
+    }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -245,17 +245,31 @@ public class StoreController {
                         storeDetailService.findAllStoreIntroductions()));
     }
 
-    @PatchMapping("/admin/stores/{storeId}/activateStatus")
-    public ResponseEntity<CustomResponse> updateStoreActivateStatus(@PathVariable long storeId) {
+    @PatchMapping("/admin/stores/{storeId}/activate")
+    public ResponseEntity<CustomResponse> activateStoreStatus(@PathVariable long storeId) {
 
-        storeMetaService.updateStoreActivateStatus(storeId);
+        storeMetaService.activateStoreStatus(storeId);
 
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
                         "success",
                         200,
-                        "협업지점 활성화 상태 변경 성공"
+                        "협업지점 활성화 성공"
+                ));
+    }
+
+    @PatchMapping("/admin/stores/{storeId}/inactivate")
+    public ResponseEntity<CustomResponse> inActivateStoreStatus(@PathVariable long storeId) {
+
+        storeMetaService.inactivateStoreStatus(storeId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "협업지점 비활성화 성공"
                 ));
     }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
+++ b/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
@@ -85,4 +85,15 @@ public class StoreExceptionHandler {
                         404,
                         ex.getMessage()));
     }
+
+    @ExceptionHandler(EssentialImageException.class)
+    public ResponseEntity<CustomErrorResponse> essentialImage(EssentialImageException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "bad request",
+                        400,
+                        ex.getMessage()));
+    }
 }

--- a/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
@@ -18,7 +18,6 @@ public class UpdateStoreRequest {
     private String category;
     private long classificationId;
     private long subClassificationId;
-    private boolean activateStatus;
     @NotBlank
     private String address;
     @NotBlank

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -56,7 +56,6 @@ public class StoreMeta {
 
         return StoreMeta.builder()
                 .name(request.getName())
-                .activated(request.isActivateStatus())
                 .deleted(false)
                 .classification(classification)
                 .subClassification(subClassification)
@@ -97,5 +96,10 @@ public class StoreMeta {
                 .anyMatch(businessHour ->
                         currentTime.toLocalTime().isAfter(businessHour.getOpenAt())
                                 && currentTime.toLocalTime().isBefore(businessHour.getCloseAt()));
+    }
+
+    public void updateStoreActivateStatus() {
+
+        this.activated = !this.activated;
     }
 }

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -98,8 +98,13 @@ public class StoreMeta {
                                 && currentTime.toLocalTime().isBefore(businessHour.getCloseAt()));
     }
 
-    public void updateStoreActivateStatus() {
+    public void activateStoreStatus() {
 
-        this.activated = !this.activated;
+        this.activated = true;
+    }
+
+    public void inactivateStoreStatus() {
+
+        this.activated = false;
     }
 }

--- a/src/main/java/upbrella/be/store/exception/EssentialImageException.java
+++ b/src/main/java/upbrella/be/store/exception/EssentialImageException.java
@@ -1,0 +1,9 @@
+package upbrella.be.store.exception;
+
+public class EssentialImageException extends RuntimeException {
+
+    public EssentialImageException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -138,4 +138,11 @@ public class StoreMetaService {
 
         return storeMetaRepository.existsByClassificationId(classificationId);
     }
+
+    @Transactional
+    public void updateStoreActivateStatus(long storeId) {
+
+        StoreMeta storeMeta = findStoreMetaById(storeId);
+        storeMeta.updateStoreActivateStatus();
+    }
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -9,11 +9,9 @@ import upbrella.be.store.dto.response.AllCurrentLocationStoreResponse;
 import upbrella.be.store.dto.response.CurrentUmbrellaStoreResponse;
 import upbrella.be.store.dto.response.SingleCurrentLocationStoreResponse;
 import upbrella.be.store.dto.response.StoreMetaWithUmbrellaCount;
-import upbrella.be.store.entity.BusinessHour;
-import upbrella.be.store.entity.Classification;
-import upbrella.be.store.entity.StoreDetail;
-import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.store.entity.*;
 import upbrella.be.store.exception.DeletedStoreDetailException;
+import upbrella.be.store.exception.EssentialImageException;
 import upbrella.be.store.exception.NonExistingStoreMetaException;
 import upbrella.be.store.repository.StoreMetaRepository;
 import upbrella.be.umbrella.entity.Umbrella;
@@ -142,7 +140,13 @@ public class StoreMetaService {
     @Transactional
     public void updateStoreActivateStatus(long storeId) {
 
-        StoreMeta storeMeta = findStoreMetaById(storeId);
-        storeMeta.updateStoreActivateStatus();
+        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+
+        Set<StoreImage> storeImages = storeDetail.getStoreImages();
+        if (storeImages == null || storeImages.isEmpty()) {
+            throw new EssentialImageException("[ERROR] 가게 이미지가 존재하지 않으면 영업지점을 활성화할 수 없습니다.");
+        }
+
+        storeDetail.getStoreMeta().updateStoreActivateStatus();
     }
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -138,7 +138,7 @@ public class StoreMetaService {
     }
 
     @Transactional
-    public void updateStoreActivateStatus(long storeId) {
+    public void activateStoreStatus(long storeId) {
 
         StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
 
@@ -147,6 +147,14 @@ public class StoreMetaService {
             throw new EssentialImageException("[ERROR] 가게 이미지가 존재하지 않으면 영업지점을 활성화할 수 없습니다.");
         }
 
-        storeDetail.getStoreMeta().updateStoreActivateStatus();
+        storeDetail.getStoreMeta().activateStoreStatus();
+    }
+
+    @Transactional
+    public void inactivateStoreStatus(long storeId) {
+
+        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+
+        storeDetail.getStoreMeta().inactivateStoreStatus();
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -901,17 +901,40 @@ class StoreControllerTest extends RestDocsSupport {
     void updateActivateStatusTest() throws Exception {
         // given
         long storeId = 1L;
-        doNothing().when(storeMetaService).updateStoreActivateStatus(storeId);
+        doNothing().when(storeMetaService).activateStoreStatus(storeId);
 
         // when
-        storeMetaService.updateStoreActivateStatus(storeId);
+        storeMetaService.activateStoreStatus(storeId);
 
         // then
         mockMvc.perform(
-                patch("/admin/stores/{storeId}/activateStatus", storeId)
+                patch("/admin/stores/{storeId}/activate", storeId)
         ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("store-update-activate-status-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("storeId").description("협업 지점 고유번호")
+                        )));
+    }
+
+    @Test
+    @DisplayName("사용자는 협업지점의 활성화 여부 상태를 변경할 수 있다.")
+    void inactivateStoreStatus() throws Exception {
+        // given
+        long storeId = 1L;
+        doNothing().when(storeMetaService).inactivateStoreStatus(storeId);
+
+        // when
+        storeMetaService.inactivateStoreStatus(storeId);
+
+        // then
+        mockMvc.perform(
+                        patch("/admin/stores/{storeId}/inactivate", storeId)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-update-inactivate-status-doc",
                         getDocumentRequest(),
                         getDocumentResponse(),
                         pathParameters(

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -895,4 +895,27 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("가게 썸네일")
                         )));
     }
+
+    @Test
+    @DisplayName("사용자는 협업지점의 활성화 여부 상태를 변경할 수 있다.")
+    void updateActivateStatusTest() throws Exception {
+        // given
+        long storeId = 1L;
+        doNothing().when(storeMetaService).updateStoreActivateStatus(storeId);
+
+        // when
+        storeMetaService.updateStoreActivateStatus(storeId);
+
+        // then
+        mockMvc.perform(
+                patch("/admin/stores/{storeId}/activateStatus", storeId)
+        ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-update-activate-status-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("storeId").description("협업 지점 고유번호")
+                        )));
+    }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -492,7 +492,6 @@ class StoreControllerTest extends RestDocsSupport {
                 .category("카테고리")
                 .classificationId(1L)
                 .subClassificationId(2L)
-                .activateStatus(true)
                 .address("주소")
                 .addressDetail("상세주소")
                 .umbrellaLocation("우산 위치")
@@ -569,8 +568,6 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("대분류 아이디"),
                                 fieldWithPath("subClassificationId").type(JsonFieldType.NUMBER)
                                         .description("소분류"),
-                                fieldWithPath("activateStatus").type(JsonFieldType.BOOLEAN)
-                                        .description("활성화 여부"),
                                 fieldWithPath("address").type(JsonFieldType.STRING)
                                         .description("주소"),
                                 fieldWithPath("addressDetail").type(JsonFieldType.STRING)

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -567,7 +567,6 @@ public class StoreDetailServiceTest {
                 .category("카테고리 수정")
                 .classificationId(3L)
                 .subClassificationId(4L)
-                .activateStatus(true)
                 .address("주소 수정")
                 .addressDetail("상세 주소 수정")
                 .umbrellaLocation("우산 위치 수정")

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.store.dto.request.CreateStoreRequest;
 import upbrella.be.store.dto.request.SingleBusinessHourRequest;
 import upbrella.be.store.dto.response.AllCurrentLocationStoreResponse;
@@ -550,5 +551,21 @@ class StoreMetaServiceTest {
                     .isInstanceOf(NonExistingStoreMetaException.class)
                     .hasMessage("[ERROR] 존재하지 않는 협업 지점 고유번호입니다.");
         }
+    }
+
+    @Test
+    @DisplayName("사용자는 협업지점의 활성화 여부를 수정할 수 있다.")
+    void updateStoreStatusTest() {
+        // given
+        StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                .set("activated", true)
+                .sample();
+        given(storeMetaRepository.findById(1L)).willReturn(Optional.of(storeMeta));
+
+        // when
+        storeMetaService.updateStoreActivateStatus(1L);
+
+        // then
+        assertThat(storeMeta.isActivated()).isFalse();
     }
 }

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -555,8 +555,59 @@ class StoreMetaServiceTest {
     }
 
     @Test
-    @DisplayName("사용자는 협업지점의 활성화 여부를 수정할 수 있다.")
+    @DisplayName("사용자는 협업지점을 활성화 할 수 있다.")
     void updateStoreStatusTest() {
+        // given
+        StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                .set("activated", false)
+                .sample();
+
+        StoreDetail storeDetail = StoreDetail.builder()
+                .id(1L)
+                .storeMeta(storeMeta)
+                .storeImages(Set.of(StoreImage.builder()
+                        .id(1L)
+                        .imageUrl("https://image.com")
+                        .build()))
+                .build();
+
+
+        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+
+        // when
+        storeMetaService.activateStoreStatus(1L);
+
+        // then
+        assertThat(storeMeta.isActivated()).isTrue();
+    }
+
+    @Test
+    @DisplayName("협업지점의 이미지가 없을 경우 활성화할 수 없다.")
+    void activateStoreStatusErrorTest() {
+        // given
+        StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                .set("activated", true)
+                .sample();
+
+        StoreDetail storeDetail = StoreDetail.builder()
+                .id(1L)
+                .storeMeta(storeMeta)
+                .storeImages(Set.of())
+                .build();
+
+        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> storeMetaService.activateStoreStatus(1L))
+                .isInstanceOf(EssentialImageException.class)
+                .hasMessage("[ERROR] 가게 이미지가 존재하지 않으면 영업지점을 활성화할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("사용자는 협업지점을 비활성화 할 수 있다.")
+    void inactivateStoreTest() {
         // given
         StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
                 .set("activated", true)
@@ -575,33 +626,9 @@ class StoreMetaServiceTest {
         given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
 
         // when
-        storeMetaService.updateStoreActivateStatus(1L);
+        storeMetaService.inactivateStoreStatus(1L);
 
         // then
         assertThat(storeMeta.isActivated()).isFalse();
-    }
-
-    @Test
-    @DisplayName("협업지점의 이미지가 없을 경우 활성화할 수 없다.")
-    void test() {
-        // given
-        StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
-                .set("activated", true)
-                .sample();
-
-        StoreDetail storeDetail = StoreDetail.builder()
-                .id(1L)
-                .storeMeta(storeMeta)
-                .storeImages(Set.of())
-                .build();
-
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
-
-        // when
-
-        // then
-        assertThatThrownBy(() -> storeMetaService.updateStoreActivateStatus(1L))
-                .isInstanceOf(EssentialImageException.class)
-                .hasMessage("[ERROR] 가게 이미지가 존재하지 않으면 영업지점을 활성화할 수 없습니다.");
     }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #240 
- 협업지점의 사진이 있을 경우만 활성화 가능 
- 비활성화의 경우 사진 유무와 관계없이 비활성화 가능 

## 🧩 고민과 해결과정
- 협업지점 활성화 비활성화를 하나의 api로 사용할까 했지만, 활성화하는 경우 추가적인 로직이 필요하여 api를 분리하였습니다. 
