### PR TITLE
[fix] 정상적으로 로그인하지 않은 경우 예외처리 추가 (#263)

### DIFF
--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -35,7 +35,7 @@ public class UserController {
     public ResponseEntity<CustomResponse<UserInfoResponse>> findUserInfo(HttpSession httpSession) {
 
         SessionUser sessionUser = (SessionUser) httpSession.getAttribute("user");
-        User user = userService.findDecryptedUserById(sessionUser.getId());
+        User user = userService.findDecryptedUserById(sessionUser);
 
         return ResponseEntity
                 .ok()

--- a/src/main/java/upbrella/be/user/controller/UserExceptionHandler.java
+++ b/src/main/java/upbrella/be/user/controller/UserExceptionHandler.java
@@ -64,4 +64,15 @@ public class UserExceptionHandler {
                         400,
                         "소셜 로그인을 먼저 진행해주세요."));
     }
+
+    @ExceptionHandler(NotLoginException.class)
+    public ResponseEntity<CustomErrorResponse> notLogin(NotLoginException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "fail",
+                        400,
+                        "로그인이 필요합니다."));
+    }
 }

--- a/src/main/java/upbrella/be/user/exception/NotLoginException.java
+++ b/src/main/java/upbrella/be/user/exception/NotLoginException.java
@@ -1,0 +1,8 @@
+package upbrella.be.user.exception;
+
+public class NotLoginException extends RuntimeException{
+
+    public NotLoginException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -13,6 +13,7 @@ import upbrella.be.user.entity.User;
 import upbrella.be.user.exception.BlackListUserException;
 import upbrella.be.user.exception.ExistingMemberException;
 import upbrella.be.user.exception.NonExistingMemberException;
+import upbrella.be.user.exception.NotLoginException;
 import upbrella.be.user.repository.BlackListRepository;
 import upbrella.be.user.repository.UserRepository;
 import upbrella.be.util.AesEncryptor;
@@ -110,7 +111,14 @@ public class UserService {
     }
 
 
-    public User findDecryptedUserById(Long id) {
+    public User findDecryptedUserById(SessionUser sessionUser) {
+
+        Long id;
+        try {
+            id = sessionUser.getId();
+        } catch (NullPointerException e) {
+            throw new NotLoginException("[ERROR] 로그인이 필요합니다.");
+        }
 
         // Deep copy 객체를 반환함에 유의
         return userRepository.findById(id)

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -76,7 +76,7 @@ public class UserControllerTest extends RestDocsSupport {
 
         session.setAttribute("user", sessionUser);
         User decryptedUser = user.decryptData(aesEncryptor);
-        given(userService.findDecryptedUserById(anyLong()))
+        given(userService.findDecryptedUserById(sessionUser))
                 .willReturn(decryptedUser);
 
         // when & then

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -448,4 +448,17 @@ class UserServiceTest {
         // then
         assertThat(user.isAdminStatus()).isTrue();
     }
+
+    @Test
+    @DisplayName("정상적으로 로그인하지 않은 경우 개인정보 조회를 할 수 없다.")
+    void notLoginException() {
+        // given
+        SessionUser user = SessionUser.builder().build();
+
+        // when
+
+        // then
+        assertThatThrownBy(() -> userService.findDecryptedUserById(user))
+                .isInstanceOf(NonExistingMemberException.class);
+    }
 }


### PR DESCRIPTION
## 🟢 구현내용
- #263 

## 🧩 고민과 해결과정
- 세션 설정이 제대로 되지 않고 유저 정보 조회를 하는 경우 nullPointerException이 발생하는 경우가 있어 예외처리를 해주었습니다.