### PR TITLE
[fix] 유저 대여 내역 조회, 어드민 대여 내역 조회 시 정렬 로직을 ID 역순 정렬로 변경(#253)

### DIFF
--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
@@ -30,9 +30,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
                 .join(history.rentStoreMeta, storeMeta).fetchJoin()
                 .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(filterRefunded(filter))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
+                .orderBy(history.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -43,15 +41,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
 
         return queryFactory
                 .selectFrom(history)
-                .join(history.user, user).fetchJoin()
-                .leftJoin(history.refundedBy, user).fetchJoin()
-                .join(history.umbrella, umbrella).fetchJoin()
-                .join(history.rentStoreMeta, storeMeta).fetchJoin()
-                .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(filterRefunded(filter))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
                 .fetchCount();
     }
 
@@ -66,9 +56,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
                 .join(history.rentStoreMeta, storeMeta).fetchJoin()
                 .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(history.user.id.eq(userId))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
+                .orderBy(history.id.desc())
                 .fetch();
     }
 


### PR DESCRIPTION
## 🟢 구현내용

- #253 

기존 정렬 방식에서는 대여 상태가 변경되었을 때 정렬때문에 기존 row를 찾기 어렵다고하시는 의견이 있어 PK 역순으로만 정렬하는 로직으로 변경했습니다.
카운트 쿼리에서 fetch join 및 정렬 로직 삭제, 사용자 대여 내역 조회도 동일하게 적용했습니다.