### PR TITLE
[fix] 탈퇴하거나 블랙리스트에 이미 등재된 회원 블랙 요청 시 예외 반환(#277)

### DIFF
--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -98,6 +98,10 @@ public class UserService {
 
         User foundUser = findUserById(id);
         Long socialId = foundUser.getSocialId();
+
+        if (socialId == 0L) {
+            throw new NonExistingMemberException("[ERROR] 탈퇴하였거나 이미 블랙리스트 처리된 회원입니다.");
+        }
         BlackList newBlackList = BlackList.createNewBlackList(socialId);
         blackListRepository.save(newBlackList);
 


### PR DESCRIPTION
## 🟢 구현내용
- #277 

ID가 0인 회원(탈퇴 or 블랙)은 블랙리스트 등록 요청이 발생 시 400 에러를 반환하도록 처리했습니다.
