### PR TITLE
[fix, test] User 통합 테스트 작성 및 사용자 목록, 블랙리스트 목록에서 Social ID 필드 삭제 (#274, #188)

### DIFF
--- a/src/main/java/upbrella/be/config/AuthConfig.java
+++ b/src/main/java/upbrella/be/config/AuthConfig.java
@@ -13,6 +13,7 @@ import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
 
 @Configuration
 @RequiredArgsConstructor
+@Profile("!test")
 public class AuthConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -163,7 +163,7 @@ public class UserController {
     }
 
     @GetMapping("/users/histories")
-    public ResponseEntity<CustomResponse> readUserHistories(HttpSession session) {
+    public ResponseEntity<CustomResponse<AllHistoryResponse>> readUserHistories(HttpSession session) {
 
         SessionUser sessionUser = (SessionUser) session.getAttribute("user");
 

--- a/src/main/java/upbrella/be/user/dto/response/SingleBlackListResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/SingleBlackListResponse.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 public class SingleBlackListResponse {
 
     private long id;
-    private long socialId;
     @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss")
     private LocalDateTime blockedAt;
 
@@ -20,7 +19,6 @@ public class SingleBlackListResponse {
 
         return SingleBlackListResponse.builder()
                 .id(blackList.getId())
-                .socialId(blackList.getSocialId())
                 .blockedAt(blackList.getBlockedAt())
                 .build();
     }

--- a/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
@@ -9,7 +9,6 @@ import upbrella.be.user.entity.User;
 public class SingleUserInfoResponse {
 
     private long id;
-    private long socialId;
     private String name;
     private String phoneNumber;
     private String email;
@@ -21,7 +20,6 @@ public class SingleUserInfoResponse {
 
         return SingleUserInfoResponse.builder()
                 .id(user.getId())
-                .socialId(user.getSocialId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .email(user.getEmail())

--- a/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
+++ b/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
@@ -1,0 +1,50 @@
+package upbrella.be.config.interceptor;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
+import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
+
+@Configuration
+@RequiredArgsConstructor
+public class AuthTestConfig implements WebMvcConfigurer {
+
+    private final LoginInterceptor loginInterceptor;
+    private final AdminInterceptor adminInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(loginInterceptor)
+                .order(HIGHEST_PRECEDENCE)
+                .addPathPatterns("/**")
+                .excludePathPatterns(
+                        "/oauth/token",
+                        "/user/me",
+                        "/users/login/**",
+                        "/users/oauth/login/**",
+                        "/users/join/**",
+                        "/stores/**",
+                        "/index.html",
+                        "/error/**",
+                        "/api/error/**",
+                        "/docs/**");
+
+
+        registry.addInterceptor(adminInterceptor)
+                .order(LOWEST_PRECEDENCE)
+                .addPathPatterns("/admin/**")
+                .excludePathPatterns(
+                        "/oauth/token",
+                        "/user/me",
+                        "/users/login/**",
+                        "/users/oauth/login/**",
+                        "/users/join/**",
+                        "/index.html",
+                        "/error/**",
+                        "/api/error/**",
+                        "/docs/**");
+    }
+}

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -458,8 +458,6 @@ public class UserControllerTest extends RestDocsSupport {
                                         .description("회원 정보 목록"),
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER)
                                         .description("사용자 고유번호"),
-                                fieldWithPath("users[].socialId").type(JsonFieldType.NUMBER)
-                                        .description("사용자 소셜 고유번호"),
                                 fieldWithPath("users[].name").type(JsonFieldType.STRING)
                                         .description("사용자 이름"),
                                 fieldWithPath("users[].phoneNumber").type(JsonFieldType.STRING)
@@ -633,7 +631,6 @@ public class UserControllerTest extends RestDocsSupport {
         AllBlackListResponse blackLists = AllBlackListResponse.builder()
                 .blackList(List.of(SingleBlackListResponse.builder()
                         .id(1L)
-                        .socialId(1L)
                         .blockedAt(LocalDateTime.now())
                         .build()))
                 .build();
@@ -656,8 +653,6 @@ public class UserControllerTest extends RestDocsSupport {
                                         .description("블랙리스트 목록"),
                                 fieldWithPath("blackList[].id").type(JsonFieldType.NUMBER)
                                         .description("블랙리스트 고유번호"),
-                                fieldWithPath("blackList[].socialId").type(JsonFieldType.NUMBER)
-                                        .description("블랙리스트 소셜 고유번호"),
                                 fieldWithPath("blackList[].blockedAt")
                                         .description("블랙리스트 등록 날짜")
                         )));

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -232,44 +232,45 @@ public class UserControllerTest extends RestDocsSupport {
                             assertThat(result.getResolvedException())
                                     .isInstanceOf(InvalidLoginCodeException.class));
         }
-
-        @Test
-        @DisplayName("회원인 경우 로그인이 진행된다.")
-        void upbrellaLoginTest() throws Exception {
-            // given
-
-            KakaoLoginResponse kakaoUser = KakaoLoginResponse.builder()
-                    .id(1L)
-                    .kakaoAccount(
-                            KakaoAccount.builder()
-                                    .email("email@email.com")
-                                    .build())
-                    .build();
-
-            MockHttpSession session = new MockHttpSession();
-
-            SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
-            session.setAttribute("kakaoUser", kakaoUser);
-            given(userService.login(any())).willReturn(sessionUser);
-
-            // when
-
-            // then
-            mockMvc.perform(
-                            post("/users/login")
-                                    .session(session)
-                    ).andDo(print())
-                    .andExpect(status().isOk())
-                    .andDo(document("user-upbrella-login-doc",
-                            getDocumentRequest(),
-                            getDocumentResponse()
-                    ));
-        }
     }
 
     @Test
+    @DisplayName("사용자는 소셜 로그인 상태에서 업브렐라 로그인을 할 수 있다.")
+    void upbrellaLoginTest() throws Exception {
+        // given
+
+        KakaoLoginResponse kakaoUser = KakaoLoginResponse.builder()
+                .id(1L)
+                .kakaoAccount(
+                        KakaoAccount.builder()
+                                .email("email@email.com")
+                                .build())
+                .build();
+
+        MockHttpSession session = new MockHttpSession();
+
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        session.setAttribute("kakaoUser", kakaoUser);
+        given(userService.login(any())).willReturn(sessionUser);
+
+        // when
+
+        // then
+        mockMvc.perform(
+                        post("/users/login")
+                                .session(session)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("user-upbrella-login-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse()
+                ));
+    }
+
+
+    @Test
     @DisplayName("사용자는 로그아웃을 할 수 있다.")
-    void loginSuccess() throws Exception {
+    void logoutTest() throws Exception {
 
         // given
         MockHttpSession mockHttpSession = new MockHttpSession();

--- a/src/test/java/upbrella/be/user/integration/MockKakaoServerController.java
+++ b/src/test/java/upbrella/be/user/integration/MockKakaoServerController.java
@@ -1,0 +1,43 @@
+package upbrella.be.user.integration;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import upbrella.be.user.dto.request.KakaoAccount;
+import upbrella.be.user.dto.response.KakaoLoginResponse;
+import upbrella.be.user.dto.token.OauthToken;
+
+@RestController
+public class MockKakaoServerController {
+
+    @PostMapping(path = "/oauth/token")
+    public ResponseEntity<OauthToken> getAccessToken(HttpEntity<String> request) {
+
+        OauthToken response = OauthToken.builder()
+                .accessToken("access_token")
+                .refreshToken("refresh_token")
+                .tokenType("bearer")
+                .expiresIn(3600L)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping(path = "/user/me", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<KakaoLoginResponse> getMemberInfo(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        KakaoLoginResponse response = KakaoLoginResponse.builder()
+                .id(1L)
+                .kakaoAccount(KakaoAccount.builder()
+                        .email("email@email.com")
+                        .build())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/upbrella/be/user/integration/UserIntegrationTest.java
+++ b/src/test/java/upbrella/be/user/integration/UserIntegrationTest.java
@@ -1,0 +1,469 @@
+package upbrella.be.user.integration;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.transaction.annotation.Transactional;
+import upbrella.be.config.FixtureBuilderFactory;
+import upbrella.be.docs.utils.RestDocsSupport;
+import upbrella.be.rent.entity.History;
+import upbrella.be.rent.service.RentService;
+import upbrella.be.store.entity.Classification;
+import upbrella.be.store.entity.ClassificationType;
+import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.user.controller.UserController;
+import upbrella.be.user.dto.request.JoinRequest;
+import upbrella.be.user.dto.request.LoginCodeRequest;
+import upbrella.be.user.dto.request.UpdateBankAccountRequest;
+import upbrella.be.user.dto.token.KakaoOauthInfo;
+import upbrella.be.user.entity.BlackList;
+import upbrella.be.user.entity.User;
+import upbrella.be.user.repository.BlackListRepository;
+import upbrella.be.user.service.OauthLoginService;
+import upbrella.be.user.service.UserService;
+import upbrella.be.util.AesEncryptor;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+public class UserIntegrationTest extends RestDocsSupport {
+
+    @Autowired
+    private OauthLoginService oauthLoginService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private KakaoOauthInfo kakaoOauthInfo;
+    @Autowired
+    private RentService rentService;
+    @Autowired
+    private AesEncryptor aesEncryptor;
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private BlackListRepository blackListRepository;
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+    private User user;
+
+    @Override
+    protected Object initController() {
+        return new UserController(oauthLoginService, userService, kakaoOauthInfo, rentService);
+    }
+    @Nested
+    class contextJoined {
+
+        @BeforeEach
+        void setUp() {
+            Classification classification = FixtureBuilderFactory.builderClassification()
+                    .set("type", ClassificationType.CLASSIFICATION)
+                    .set("id", null).sample();
+
+            Classification subClassification = FixtureBuilderFactory.builderClassification()
+                    .set("type", ClassificationType.SUB_CLASSIFICATION)
+                    .set("id", null).sample();
+
+            em.persist(classification);
+            em.persist(subClassification);
+            em.flush();
+
+            user = FixtureBuilderFactory.builderUser(aesEncryptor)
+                    .set("id", null)
+                    .set("socialId", 1L)
+                    .sample();
+
+            em.persist(user);
+            em.flush();
+
+            StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                    .set("id", null)
+                    .set("classification", classification)
+                    .set("subClassification", subClassification)
+                    .set("businessHours", null)
+                    .sample();
+
+            em.persist(storeMeta);
+            em.flush();
+
+            Umbrella umbrella = FixtureBuilderFactory.builderUmbrella()
+                    .set("id", null)
+                    .set("storeMeta", storeMeta)
+                    .sample();
+
+            em.persist(umbrella);
+            em.flush();
+
+            History history = FixtureBuilderFactory.builderHistory(aesEncryptor)
+                    .set("id", null)
+                    .set("umbrella", umbrella)
+                    .set("user", user)
+                    .set("returnedAt", null)
+                    .set("rentStoreMeta", storeMeta)
+                    .set("returnStoreMeta", null)
+                    .set("paidBy", user)
+                    .set("refundedBy", null)
+                    .sample();
+
+            em.persist(history);
+            em.flush();
+
+        }
+
+
+        @Test
+        @DisplayName("사용자는 카카오 소셜 로그인을 할 수 있다.")
+        void socialLoginTest() throws Exception {
+
+            // given
+            LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+
+            // when
+            mockMvc.perform(
+                            post("/users/oauth/login")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(code))
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            assertThat(mockHttpSession.getAttribute("kakaoUser")).isNotNull();
+        }
+
+
+        @Test
+        @DisplayName("사용자는 소셜 로그인 상태에서 업브렐라 로그인을 할 수 있다.")
+        void upbrellaLoginTest() throws Exception {
+
+            // given
+            LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+
+            // when & then
+            mockMvc.perform(
+                            post("/users/oauth/login")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(code))
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(
+                            post("/users/login")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            assertThat(mockHttpSession.getAttribute("kakaoUser")).isNull();
+            assertThat(mockHttpSession.getAttribute("user")).isNotNull();
+        }
+
+        @DisplayName("사용자는 로그인된 유저 정보를 조회할 수 있다.")
+        @Test
+        void findUserInfoTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/loggedIn")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").exists())
+                    .andExpect(jsonPath("$.data.phoneNumber").exists())
+                    .andExpect(jsonPath("$.data.name").exists())
+                    .andExpect(jsonPath("$.data.bank").exists())
+                    .andExpect(jsonPath("$.data.accountNumber").exists());
+        }
+
+        @Test
+        @DisplayName("사용자는 유저가 빌린 우산을 조회할 수 있다.")
+        void findUmbrellaBorrowedByUserTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/loggedIn/umbrella")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.uuid").exists())
+                    .andExpect(jsonPath("$.data.elapsedDay").exists());
+        }
+
+
+        @Test
+        @DisplayName("사용자는 로그아웃을 할 수 있다.")
+        void logoutTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", 1L).sample());
+
+            // when
+            mockMvc.perform(
+                            post("/users/logout")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            // then
+            assertThat(mockHttpSession.isInvalid()).isEqualTo(true);
+        }
+
+        @DisplayName("사용자는 회원 정보 목록을 조회할 수 있다.")
+        @Test
+        void findUsersInfoTest() throws Exception {
+
+            // when & then
+            mockMvc.perform(
+                            get("/admin/users")
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").exists())
+                    .andExpect(jsonPath("$.data.users.length()").value(1))
+                    .andExpect(jsonPath("$.data.users[0].id").exists())
+                    .andExpect(jsonPath("$.data.users[0].name").exists())
+                    .andExpect(jsonPath("$.data.users[0].phoneNumber").exists())
+                    .andExpect(jsonPath("$.data.users[0].bank").exists())
+                    .andExpect(jsonPath("$.data.users[0].accountNumber").exists())
+                    .andExpect(jsonPath("$.data.users[0].adminStatus").exists());
+        }
+
+        @Test
+        @DisplayName("로그인된 사용자는 우산 대여 정보를 조회할 수 있다.")
+        void readUserHistoriesTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/histories")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").exists())
+                    .andExpect(jsonPath("$.data.histories.length()").value(1))
+                    .andExpect(jsonPath("$.data.histories[0].umbrellaUuid").exists())
+                    .andExpect(jsonPath("$.data.histories[0].rentedAt").exists())
+                    .andExpect(jsonPath("$.data.histories[0].rentedStore").exists())
+                    .andExpect(jsonPath("$.data.histories[0].returned").value(false))
+                    .andExpect(jsonPath("$.data.histories[0].returned").exists());
+        }
+
+        @Test
+        @DisplayName("사용자는 은행 정보를 수정할 수 있다.")
+        void updateUserBankAccount() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+            UpdateBankAccountRequest updateBankAccountRequest = FixtureBuilderFactory.builderBankAccount().sample();
+
+            // when
+            mockMvc.perform(
+                    patch("/users/bankAccount")
+                            .session(mockHttpSession)
+                            .content(objectMapper.writeValueAsString(updateBankAccountRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            // then
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(aesEncryptor.decrypt(foundUser.getBank())).isEqualTo(updateBankAccountRequest.getBank()),
+                    () -> assertThat(aesEncryptor.decrypt(foundUser.getAccountNumber())).isEqualTo(updateBankAccountRequest.getAccountNumber())
+            );
+        }
+
+        @Test
+        @DisplayName("사용자가 회원탈퇴를 하면, 삭제된 회원 정보로 변경되고 회원은 탈퇴된다.")
+        void deleteUserTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when
+            mockMvc.perform(
+                    delete("/users/loggedIn")
+                            .session(mockHttpSession)
+            ).andExpect(status().isOk());
+
+            // then
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(foundUser.getSocialId()).isEqualTo(0L),
+                    () -> assertThat(foundUser.getAccountNumber()).isEqualTo(null),
+                    () -> assertThat(foundUser.getBank()).isEqualTo(null),
+                    () -> assertThat(foundUser.getPhoneNumber()).isEqualTo("deleted"),
+                    () -> assertThat(foundUser.getName()).isEqualTo("탈퇴한 회원")
+            );
+
+
+        }
+
+        @Test
+        @DisplayName("관리자가 회원탈퇴 시키면, 블랙리스트에 추가되고 회원탈퇴가 된다.")
+        void withdrawUserTest() throws Exception {
+
+            // given
+            long userId = user.getId();
+
+            // when
+            mockMvc.perform(
+                            delete("/admin/users/{userId}", userId)
+                                    .session(mockHttpSession)
+                    ).andExpect(status().isOk())
+                    .andDo(print());
+
+            // then
+            assertThat(blackListRepository.findAll().size()).isEqualTo(1);
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(foundUser.getSocialId()).isEqualTo(0L),
+                    () -> assertThat(foundUser.getAccountNumber()).isEqualTo(null),
+                    () -> assertThat(foundUser.getBank()).isEqualTo(null),
+                    () -> assertThat(foundUser.getPhoneNumber()).isEqualTo("deleted"),
+                    () -> assertThat(foundUser.getName()).isEqualTo("정지된 회원")
+            );
+        }
+
+
+
+        @Test
+        @DisplayName("사용자는 자신의 계좌정보를 삭제할 수 있다.")
+        void deleteBackAccountTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when
+            mockMvc.perform(
+                            delete("/users/bankAccount")
+                                    .session(mockHttpSession)
+                    ).andExpect(status().isOk());
+
+            // then
+            assertThat(em.find(User.class, user.getId()).getBank()).isNull();
+        }
+
+    }
+
+
+
+    @Test
+    @DisplayName("사용자는 카카오 소셜 로그인 후 회원 가입을 할 수 있다.")
+    void joinTest() throws Exception {
+
+        // given
+        LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+        mockMvc.perform(
+                        post("/users/oauth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(code))
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        JoinRequest joinRequest = FixtureBuilderFactory.builderJoinRequest().sample();
+
+        // when
+        mockMvc.perform(
+                        post("/users/join")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(joinRequest))
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(User.class, 1L)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("사용자는 블랙리스트를 조회할 수 있다.")
+    void findAllBlackListTest() throws Exception {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        BlackList blackList = BlackList.builder()
+                .blockedAt(now)
+                .socialId(123L)
+                .build();
+
+        em.persist(blackList);
+        em.flush();
+
+        // then
+        mockMvc.perform(
+                        get("/users/blackList")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.blackList.length()").value(1))
+                .andExpect(jsonPath("$.data.blackList[0].id").value(blackList.getId()))
+                .andExpect(jsonPath("$.data.blackList[0].blockedAt").exists());
+    }
+
+    @Test
+    @DisplayName("사용자는 블랙리스트를 삭제할 수 있다.")
+    void deleteBlackListTest() throws Exception {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        BlackList blackList = BlackList.builder()
+                .blockedAt(now)
+                .socialId(123L)
+                .build();
+
+        em.persist(blackList);
+        em.flush();
+
+        // when
+        mockMvc.perform(
+                        delete("/users/blackList/{blackListId}", blackList.getId())
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(BlackList.class, blackList.getId())).isNull();
+    }
+
+
+    @Test
+    @DisplayName("관리자가 회원의 관리자 상태를 변경할 수 있다.")
+    void updateAdminStatusTest() throws Exception {
+
+        // given
+        User user = FixtureBuilderFactory.builderUser(aesEncryptor)
+                .set("id", null)
+                .set("socialId", 1L)
+                .set("adminStatus", false)
+                .sample();
+
+        em.persist(user);
+        em.flush();
+
+        // when
+        mockMvc.perform(
+                        patch("/admin/users/{userId}", user.getId())
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(User.class, user.getId()).isAdminStatus()).isTrue();
+    }
+}

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -413,7 +413,6 @@ class UserServiceTest {
         // then
         assertAll(
                 () -> assertThat(userService.findBlackList().getBlackList().size()).isEqualTo(1),
-                () -> assertThat(userService.findBlackList().getBlackList().get(0).getSocialId()).isEqualTo(1L),
                 () -> assertThat(userService.findBlackList().getBlackList().get(0).getBlockedAt()).isEqualTo(now)
         );
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    import: "classpath:application.properties"
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show-sql: true
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+    timeout: 60000
+  session:
+    store-type: redis
+    timeout: 3600
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql: trace
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
## 🟢 구현내용
- #274 
- #188 

## 🧩 고민과 해결과정
- social ID를 유저 목록 조회, 블랙리스트 목록 조회에서 보여주지 않도록 변경했습니다. 
- User 통합 테스트 작성했습니다. 카카오 API 테스팅에는 mocking이 통합 테스트에는 비적합하여 8888포트에서 카카오 서버처럼 요청을 처리해주는 RestController를 구현해 token과 개인정보를 반환하도록 작성했습니다.
- Test에서는 mock server를 위한 url도 열어줘야해서 test 프로필 용 인터셉터 설정을 추가했습니다.