### PR TITLE
[fix] 우산 Admin 현재 대여 번호, 협업 지점 이름, 협업 지점 ID 통일 (#282)

### DIFF
--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -27,8 +27,8 @@ public class StoreController {
     private final ClassificationService classificationService;
     private final StoreDetailService storeDetailService;
 
-    @GetMapping("/stores/{storeDetailId}")
-    public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(@PathVariable long storeDetailId) {
+    @GetMapping("/stores/{storeId}")
+    public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(@PathVariable long storeId) {
 
         return ResponseEntity
                 .ok()
@@ -36,7 +36,7 @@ public class StoreController {
                         "success",
                         200,
                         "가게 조회 성공",
-                        storeDetailService.findStoreDetailByStoreMetaId(storeDetailId)));
+                        storeDetailService.findStoreDetailByStoreId(storeId)));
     }
 
     @GetMapping("/stores/classification/{classificationId}")

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
@@ -35,7 +35,7 @@ public class SingleStoreIntroductionResponse {
         String thumbnail = createThumbnail(sortedImageUrls);
         StoreMeta storeMeta = storeDetail.getStoreMeta();
 
-        return of(storeDetail.getStoreMeta().getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
+        return of(storeMeta.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
     }
 
     private static String createThumbnail(List<SingleImageUrlResponse> imageUrls) {

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
@@ -35,7 +35,7 @@ public class SingleStoreIntroductionResponse {
         String thumbnail = createThumbnail(sortedImageUrls);
         StoreMeta storeMeta = storeDetail.getStoreMeta();
 
-        return of(storeDetail.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
+        return of(storeDetail.getStoreMeta().getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
     }
 
     private static String createThumbnail(List<SingleImageUrlResponse> imageUrls) {

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -34,7 +34,7 @@ public class SingleStoreResponse {
     public static SingleStoreResponse ofCreateSingleStoreResponse(StoreDetail storeDetail, String thumbnail, List<SingleImageUrlResponse> images, List<SingleBusinessHourResponse> businessHours) {
 
         return SingleStoreResponse.builder()
-                .id(storeDetail.getId())
+                .id(storeDetail.getStoreMeta().getId())
                 .name(storeDetail.getStoreMeta().getName())
                 .category(storeDetail.getStoreMeta().getCategory())
                 .classification(SingleClassificationResponse.ofCreateClassification(storeDetail.getStoreMeta().getClassification()))

--- a/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
@@ -31,7 +31,7 @@ public class StoreFindByIdResponse {
     public static StoreFindByIdResponse fromStoreDetail(StoreDetail storeDetail, long availableUmbrellaCount) {
 
         return StoreFindByIdResponse.builder()
-                .id(storeDetail.getId())
+                .id(storeDetail.getStoreMeta().getId())
                 .name(storeDetail.getStoreMeta().getName())
                 .businessHours(storeDetail.getWorkingHour())
                 .contactNumber(storeDetail.getContactInfo())

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -29,7 +29,7 @@ public class StoreDetailService {
     @Transactional
     public void updateStore(Long storeId, UpdateStoreRequest request) {
 
-        StoreDetail storeDetailById = findStoreDetailById(storeId);
+        StoreDetail storeDetailById = findStoreDetailByStoreMetaId(storeId);
         long storeMetaId = storeDetailById.getStoreMeta().getId();
 
         Classification classification = classificationService.findClassificationById(request.getClassificationId());
@@ -46,19 +46,18 @@ public class StoreDetailService {
     }
 
     @Transactional(readOnly = true)
-    public StoreDetail findStoreDetailById(Long storeId) {
+    public StoreDetail findStoreDetailByStoreMetaId(Long storeId) {
 
-        return storeDetailRepository.findById(storeId)
+        return storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeId)
                 .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 존재하지 않는 가게입니다."));
     }
 
     @Transactional
-    public StoreFindByIdResponse findStoreDetailByStoreMetaId(long storeDetailId) {
+    public StoreFindByIdResponse findStoreDetailByStoreId(long storeId) {
 
-        StoreDetail storeDetail = findStoreDetailById(storeDetailId);
-        long storeMetaId = storeDetail.getStoreMeta().getId();
+        StoreDetail storeDetail = findStoreDetailByStoreMetaId(storeId);
 
-        long availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeMetaId);
+        long availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeId);
 
         return StoreFindByIdResponse.fromStoreDetail(storeDetail, availableUmbrellaCount);
     }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -91,10 +91,9 @@ public class StoreMetaService {
     }
 
     @Transactional
-    public void deleteStoreMeta(long storeDetailId) {
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeDetailId);
+    public void deleteStoreMeta(long storeMetaId) {
 
-        findStoreMetaById(storeDetail.getStoreMeta().getId()).delete();
+        findStoreMetaById(storeMetaId).delete();
     }
 
     @Transactional(readOnly = true)
@@ -140,7 +139,7 @@ public class StoreMetaService {
     @Transactional
     public void activateStoreStatus(long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         Set<StoreImage> storeImages = storeDetail.getStoreImages();
         if (storeImages == null || storeImages.isEmpty()) {
@@ -153,7 +152,7 @@ public class StoreMetaService {
     @Transactional
     public void inactivateStoreStatus(long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         storeDetail.getStoreMeta().inactivateStoreStatus();
     }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -10,6 +10,7 @@ public class UmbrellaResponse {
 
     private long id;
     private long storeMetaId;
+    private String storeName;
     private long uuid;
     private boolean rentable;
 
@@ -18,6 +19,7 @@ public class UmbrellaResponse {
                 .id(umbrella.getId())
                 .rentable(umbrella.isRentable())
                 .storeMetaId(umbrella.getStoreMeta().getId())
+                .storeName(umbrella.getStoreMeta().getName())
                 .uuid(umbrella.getUuid())
                 .build();
     }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -2,25 +2,27 @@ package upbrella.be.umbrella.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import upbrella.be.umbrella.entity.Umbrella;
 
 @Getter
 @Builder
 public class UmbrellaResponse {
 
     private long id;
+    private Long historyId;
     private long storeMetaId;
     private String storeName;
     private long uuid;
     private boolean rentable;
 
-    public static UmbrellaResponse fromUmbrella(Umbrella umbrella) {
+    public static UmbrellaResponse fromUmbrella(UmbrellaWithHistory umbrellaWithHistory) {
+
         return UmbrellaResponse.builder()
-                .id(umbrella.getId())
-                .rentable(umbrella.isRentable())
-                .storeMetaId(umbrella.getStoreMeta().getId())
-                .storeName(umbrella.getStoreMeta().getName())
-                .uuid(umbrella.getUuid())
+                .id(umbrellaWithHistory.getId())
+                .historyId(umbrellaWithHistory.getHistoryId())
+                .rentable(umbrellaWithHistory.isRentable())
+                .storeMetaId(umbrellaWithHistory.getStoreMeta().getId())
+                .storeName(umbrellaWithHistory.getStoreMeta().getName())
+                .uuid(umbrellaWithHistory.getUuid())
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
@@ -1,0 +1,38 @@
+package upbrella.be.umbrella.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import upbrella.be.store.entity.StoreMeta;
+
+import java.time.LocalDateTime;
+
+
+@Getter
+@NoArgsConstructor
+public class UmbrellaWithHistory {
+
+    private long id;
+    private StoreMeta storeMeta;
+    private long uuid;
+    private boolean rentable;
+    private boolean deleted;
+    private LocalDateTime createdAt;
+    private String etc;
+    private boolean missed;
+    private Long historyId;
+
+    @QueryProjection
+    public UmbrellaWithHistory(long id, StoreMeta storeMeta, long uuid, boolean rentable, boolean deleted, LocalDateTime createdAt, String etc, boolean missed, Long historyId) {
+
+        this.id = id;
+        this.storeMeta = storeMeta;
+        this.uuid = uuid;
+        this.rentable = rentable;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+        this.etc = etc;
+        this.missed = missed;
+        this.historyId = historyId;
+    }
+}

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
@@ -1,14 +1,15 @@
 package upbrella.be.umbrella.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import upbrella.be.store.entity.StoreMeta;
 
 import java.time.LocalDateTime;
 
-
 @Getter
+@Builder
 @NoArgsConstructor
 public class UmbrellaWithHistory {
 
@@ -36,3 +37,4 @@ public class UmbrellaWithHistory {
         this.historyId = historyId;
     }
 }
+

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -11,13 +11,7 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long>, Umbre
 
     Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
 
-    boolean existsByIdAndDeletedIsFalse(long id);
-
     boolean existsByUuidAndDeletedIsFalse(long uuid);
 
     List<Umbrella> findByDeletedIsFalseOrderById(Pageable pageable);
-
-    List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
-
-
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
@@ -1,5 +1,10 @@
 package upbrella.be.umbrella.repository;
 
+import org.springframework.data.domain.Pageable;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
+
+import java.util.List;
+
 public interface UmbrellaRepositoryCustom {
 
     long countAllUmbrellas();
@@ -17,4 +22,8 @@ public interface UmbrellaRepositoryCustom {
     long countAllUmbrellasByStore(long storeId);
 
     long countMissingUmbrellasByStore(long storeId);
+
+    List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaId(Pageable pageable);
+
+    List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(long storeId, Pageable pageable);
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
@@ -2,7 +2,13 @@ package upbrella.be.umbrella.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import upbrella.be.umbrella.dto.response.QUmbrellaWithHistory;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 
+import java.util.List;
+
+import static upbrella.be.rent.entity.QHistory.history;
 import static upbrella.be.umbrella.entity.QUmbrella.umbrella;
 
 @RequiredArgsConstructor
@@ -86,5 +92,60 @@ public class UmbrellaRepositoryImpl implements UmbrellaRepositoryCustom {
                         .and(umbrella.missed.eq(true))
                         .and(umbrella.deleted.eq(false)))
                 .fetchCount();
+    }
+
+    @Override
+    public List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaId(Pageable pageable) {
+
+        QUmbrellaWithHistory umbrellaWithHistory = new QUmbrellaWithHistory(
+                umbrella.id,
+                umbrella.storeMeta,
+                umbrella.uuid,
+                umbrella.rentable,
+                umbrella.deleted,
+                umbrella.createdAt,
+                umbrella.etc,
+                umbrella.missed,
+                history.id
+        );
+
+        return queryFactory.select(umbrellaWithHistory)
+                .from(history)
+                .rightJoin(history.umbrella, umbrella)
+                .join(umbrella.storeMeta)
+                .where(umbrella.deleted.eq(false)
+                        .and(history.returnedAt.isNull()))
+                .orderBy(umbrella.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(long storeId, Pageable pageable) {
+
+        QUmbrellaWithHistory umbrellaWithHistory = new QUmbrellaWithHistory(
+                umbrella.id,
+                umbrella.storeMeta,
+                umbrella.uuid,
+                umbrella.rentable,
+                umbrella.deleted,
+                umbrella.createdAt,
+                umbrella.etc,
+                umbrella.missed,
+                history.id
+        );
+
+        return queryFactory.select(umbrellaWithHistory)
+                .from(history)
+                .rightJoin(history.umbrella, umbrella)
+                .join(umbrella.storeMeta)
+                .where(umbrella.deleted.eq(false)
+                        .and(umbrella.storeMeta.id.eq(storeId))
+                        .and(history.returnedAt.isNull()))
+                .orderBy(umbrella.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -34,14 +34,14 @@ public class UmbrellaService {
 
     public List<UmbrellaResponse> findAllUmbrellas(Pageable pageable) {
 
-        return umbrellaRepository.findByDeletedIsFalseOrderById(pageable)
+        return umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable)
                 .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toList());
     }
 
     public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId, Pageable pageable) {
 
-        return umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(storeId, pageable)
+        return umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(storeId, pageable)
                 .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toList());
     }

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -108,7 +108,8 @@ public class FixtureBuilderFactory {
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", buildLong(10000))
                 .set("storeMetaId", buildLong(100))
-                .set("uuid", buildLong(100));
+                .set("uuid", buildLong(100))
+                .set("storeName", pickRandomString(cafeList));
     }
 
     public static ArbitraryBuilder<UmbrellaCreateRequest> builderUmbrellaCreateRequest() {

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -12,6 +12,7 @@ import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
@@ -103,11 +104,23 @@ public class FixtureBuilderFactory {
                 .set("etc", pickRandomString(nameList));
     }
 
+    public static ArbitraryBuilder<UmbrellaWithHistory> builderUmbrellaWithHistory() {
+
+        return fixtureMonkey.giveMeBuilder(UmbrellaWithHistory.class)
+                .set("id", buildLong(10000))
+                .set("uuid", buildLong(1000))
+                .set("historyId", buildLong(1000))
+                .set("storeMeta", builderStoreMeta().sample())
+                .set("deleted", false)
+                .set("etc", pickRandomString(nameList));
+    }
+
     public static ArbitraryBuilder<UmbrellaResponse> builderUmbrellaResponses() {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", buildLong(10000))
                 .set("storeMetaId", buildLong(100))
+                .set("historyId", buildLong(100))
                 .set("uuid", buildLong(100))
                 .set("storeName", pickRandomString(cafeList));
     }

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -60,6 +60,7 @@ public class FixtureFactory {
                 .set("storeMetaId", storeMeta.getId())
                 .set("uuid", umbrella.getUuid())
                 .set("rentable", umbrella.isRentable())
+                .set("storeName", storeMeta.getName())
                 .sample();
     }
 

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -8,6 +8,7 @@ import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.response.KakaoLoginResponse;
@@ -53,7 +54,7 @@ public class FixtureFactory {
                 .sample();
     }
 
-    public static UmbrellaResponse buildUmbrellaResponseWithUmbrellaAndStoreMeta(Umbrella umbrella, StoreMeta storeMeta) {
+    public static UmbrellaResponse buildUmbrellaResponseWithUmbrellaAndStoreMeta(UmbrellaWithHistory umbrella, StoreMeta storeMeta) {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", umbrella.getId())
@@ -61,6 +62,7 @@ public class FixtureFactory {
                 .set("uuid", umbrella.getUuid())
                 .set("rentable", umbrella.isRentable())
                 .set("storeName", storeMeta.getName())
+                .set("historyId", umbrella.getHistoryId())
                 .sample();
     }
 

--- a/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
+++ b/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
@@ -1,19 +1,23 @@
 package upbrella.be.config.interceptor;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
 
+@Profile("test")
 @Configuration
-@RequiredArgsConstructor
-public class AuthTestConfig implements WebMvcConfigurer {
+public class AuthTestConfig implements WebMvcConfigurer  {
 
-    private final LoginInterceptor loginInterceptor;
-    private final AdminInterceptor adminInterceptor;
+    @Autowired
+    private LoginInterceptor loginInterceptor;
+    @Autowired
+    private AdminInterceptor adminInterceptor;
+
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -77,7 +77,7 @@ class StoreControllerTest extends RestDocsSupport {
                         "https://upbrella-store-image.s3.ap-northeast-2.amazonaws.com/3.jpg"))
                 .build();
 
-        given(storeDetailService.findStoreDetailByStoreMetaId(2L))
+        given(storeDetailService.findStoreDetailByStoreId(2L))
                 .willReturn(storeFindByIdResponse);
 
         // when & then

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -37,6 +37,10 @@ public class StoreDetailServiceTest {
     private UmbrellaService umbrellaService;
     @Mock
     private StoreDetailRepository storeDetailRepository;
+    @Mock
+    private BusinessHourService businessHourService;
+    @Mock
+    private StoreImageService storeImageService;
     @InjectMocks
     private StoreDetailService storeDetailService;
 

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -630,7 +630,7 @@ public class StoreDetailServiceTest {
         StoreIntroductionsResponseByClassification storeIntroductionsResponseByClassification = StoreIntroductionsResponseByClassification
                 .builder()
                 .subClassificationId(1)
-                .stores(List.of(SingleStoreIntroductionResponse.of(2L, "가게 썸네일", "스타벅스", "카페, 디저트")))
+                .stores(List.of(SingleStoreIntroductionResponse.of(3L, "가게 썸네일", "스타벅스", "카페, 디저트")))
                 .build();
 
         AllStoreIntroductionResponse expected = AllStoreIntroductionResponse.builder()

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -37,10 +37,6 @@ public class StoreDetailServiceTest {
     private UmbrellaService umbrellaService;
     @Mock
     private StoreDetailRepository storeDetailRepository;
-    @Mock
-    private BusinessHourService businessHourService;
-    @Mock
-    private StoreImageService storeImageService;
     @InjectMocks
     private StoreDetailService storeDetailService;
 
@@ -94,14 +90,14 @@ public class StoreDetailServiceTest {
 
             // given
 
-            given(storeDetailRepository.findById(3L))
+            given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(3L))
                     .willReturn(Optional.of(storeDetail));
 
             given(umbrellaService.countAvailableUmbrellaAtStore(3L))
                     .willReturn(10L);
 
             //when
-            StoreFindByIdResponse storeFindByIdResponse = storeDetailService.findStoreDetailByStoreMetaId(3L);
+            StoreFindByIdResponse storeFindByIdResponse = storeDetailService.findStoreDetailByStoreId(3L);
 
             //then
             assertAll(
@@ -109,7 +105,7 @@ public class StoreDetailServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(storeFindByIdResponseExpected),
                     () -> then(storeDetailRepository).should(times(1))
-                            .findById(3L),
+                            .findByStoreMetaIdUsingFetchJoin(3L),
                     () -> then(umbrellaService).should(times(1))
                             .countAvailableUmbrellaAtStore(3L)
             );
@@ -361,11 +357,11 @@ public class StoreDetailServiceTest {
         @DisplayName("id로 조회할 수 있다.")
         void findByIdTest() {
             // given
-            long storeDetailId = 1L;
-            given(storeDetailRepository.findById(storeDetailId)).willReturn(Optional.of(storeDetail));
+            long storeMetaId = 1L;
+            given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeMetaId)).willReturn(Optional.of(storeDetail));
 
             // when
-            StoreDetail storeDetailById = storeDetailService.findStoreDetailById(storeDetailId);
+            StoreDetail storeDetailById = storeDetailService.findStoreDetailByStoreMetaId(storeMetaId);
 
             // then
             assertAll(
@@ -386,7 +382,7 @@ public class StoreDetailServiceTest {
 
 
             // then
-            assertThatThrownBy(() -> storeDetailService.findStoreDetailById(storeDetailId))
+            assertThatThrownBy(() -> storeDetailService.findStoreDetailByStoreMetaId(storeDetailId))
                     .isInstanceOf(NonExistingStoreDetailException.class)
                     .hasMessageContaining("[ERROR] 존재하지 않는 가게입니다.");
         }
@@ -563,7 +559,7 @@ public class StoreDetailServiceTest {
                 .build();
 
 
-        given(storeDetailRepository.findById(storeId)).willReturn(Optional.of(storedetail));
+        given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeId)).willReturn(Optional.of(storedetail));
         given(classificationService.findClassificationById(request.getClassificationId())).willReturn(classificationUpdate);
         given(classificationService.findSubClassificationById(request.getSubClassificationId())).willReturn(subClassificationUpdate);
         given(storeMetaService.findStoreMetaById(storeId)).willReturn(storeMeta);
@@ -576,7 +572,7 @@ public class StoreDetailServiceTest {
         StoreMeta foundStoreMeta = storeMetaService.findStoreMetaById(storeId);
 
 
-        StoreDetail foundStoreDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail foundStoreDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         assertAll(
                 () -> assertThat(foundStoreMeta) // 업데이트된 필드에 대한 검증

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -466,7 +466,6 @@ class StoreMetaServiceTest {
                 .id(1L)
                 .storeMeta(storeMeta).build();
 
-        given(storeDetailService.findStoreDetailById(anyLong())).willReturn(storeDetail);
         given(storeMetaRepository.findById(1L)).willReturn(Optional.of(storeMeta));
 
         // when
@@ -572,7 +571,7 @@ class StoreMetaServiceTest {
                 .build();
 
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
         storeMetaService.activateStoreStatus(1L);
@@ -595,7 +594,7 @@ class StoreMetaServiceTest {
                 .storeImages(Set.of())
                 .build();
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
 
@@ -623,7 +622,7 @@ class StoreMetaServiceTest {
                 .build();
 
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
         storeMetaService.inactivateStoreStatus(1L);

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -88,6 +88,9 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                         .description("우산 목록"),
                                 fieldWithPath("umbrellaResponsePage[].id").type(JsonFieldType.NUMBER)
                                         .description("우산 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].historyId").type(JsonFieldType.NUMBER)
+                                        .description("현재 대여 내역 고유번호")
+                                        .optional(),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
                                         .description("보관 지점 고유번호"),
                                 fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)
@@ -139,6 +142,9 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                         .description("우산 목록"),
                                 fieldWithPath("umbrellaResponsePage[].id").type(JsonFieldType.NUMBER)
                                         .description("우산 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].historyId").type(JsonFieldType.NUMBER)
+                                        .description("현재 대여 내역 고유번호")
+                                        .optional(),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
                                         .description("보관 지점 고유 번호"),
                                 fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -90,6 +90,8 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                         .description("우산 고유번호"),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
                                         .description("보관 지점 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)
+                                        .description("보관 지점 이름"),
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)
@@ -138,7 +140,9 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                 fieldWithPath("umbrellaResponsePage[].id").type(JsonFieldType.NUMBER)
                                         .description("우산 고유번호"),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
-                                        .description("보관 지점번호"),
+                                        .description("보관 지점 고유 번호"),
+                                fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)
+                                        .description("보관 지점 이름"),
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -125,6 +125,7 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
         UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
                 .set("id", 999L)
                 .set("storeMetaId", storeMeta.getId())
+                .set("uuid", 3000L)
                 .sample();
 
         // when & then

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -188,6 +188,7 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
     void modifyUmbrellaTest() throws Exception {
 
         // given
+        // TODO : UUID 중복 오류 수정
         long id = umbrellaList.get(0).getId();
         UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                 .set("storeMetaId", storeMeta.getId())

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -188,7 +188,6 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
     void modifyUmbrellaTest() throws Exception {
 
         // given
-        // TODO : UUID 중복 오류 수정
         long id = umbrellaList.get(0).getId();
         UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                 .set("storeMetaId", storeMeta.getId())

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -20,6 +20,7 @@ import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
 import upbrella.be.umbrella.exception.NonExistingUmbrellaException;
@@ -57,6 +58,7 @@ class UmbrellaServiceTest {
         private StoreMeta storeMeta;
         private List<UmbrellaResponse> expectedUmbrellaResponses;
         private List<Umbrella> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellasWithHistory = new ArrayList<>();
 
         @BeforeEach
         void setUp() {
@@ -67,9 +69,13 @@ class UmbrellaServiceTest {
                 generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrella()
                         .set("storeMeta", storeMeta)
                         .sample());
+
+                generatedUmbrellasWithHistory.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
+                        .set("storeMeta", storeMeta)
+                        .sample());
             }
 
-            expectedUmbrellaResponses = generatedUmbrellas.stream()
+            expectedUmbrellaResponses = generatedUmbrellasWithHistory.stream()
                     .map(umbrella -> FixtureFactory.buildUmbrellaResponseWithUmbrellaAndStoreMeta(umbrella, storeMeta))
                     .collect(Collectors.toList());
         }
@@ -80,8 +86,8 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
-                    .willReturn(generatedUmbrellas);
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable))
+                    .willReturn(generatedUmbrellasWithHistory);
 
             //when
             List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findAllUmbrellas(pageable);
@@ -102,7 +108,7 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable))
                     .willReturn(List.of());
 
             //when
@@ -118,7 +124,8 @@ class UmbrellaServiceTest {
     class findUmbrellasByStoreIdTest {
         private StoreMeta storeMeta;
         private List<UmbrellaResponse> expectedUmbrellaResponses;
-        private List<Umbrella> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellasWithHistory = new ArrayList<>();
 
         @BeforeEach
         void setUp() {
@@ -126,12 +133,15 @@ class UmbrellaServiceTest {
             storeMeta = FixtureBuilderFactory.builderStoreMeta().sample();
 
             for (int i = 0; i < 5; i++) {
-                generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrella()
+                generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
+                        .set("storeMeta", storeMeta)
+                        .sample());
+                generatedUmbrellasWithHistory.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
                         .set("storeMeta", storeMeta)
                         .sample());
             }
 
-            expectedUmbrellaResponses = generatedUmbrellas.stream()
+            expectedUmbrellaResponses = generatedUmbrellasWithHistory.stream()
                     .map(umbrella -> FixtureFactory.buildUmbrellaResponseWithUmbrellaAndStoreMeta(umbrella, storeMeta))
                     .collect(Collectors.toList());
         }
@@ -141,8 +151,8 @@ class UmbrellaServiceTest {
         void success() {
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
-                    .willReturn(generatedUmbrellas);
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(2L, pageable))
+                    .willReturn(generatedUmbrellasWithHistory);
 
             //when
             List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findUmbrellasByStoreId(2L, pageable);
@@ -163,7 +173,7 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(2L, pageable))
                     .willReturn(List.of());
 
             //when


### PR DESCRIPTION
## 🟢 구현내용
- #282 

1. 우산 Admin 대여 일련 번호 추가
2. 우산 현재 대여 번호 조회 및 협업 지점 이름 필드 추가
3. 협업지점 API에서 StoreMeta ID로 조회하도록 전체적인 기능 통일

