### PR TITLE
 v0.3.4 dev pre-release

### DIFF
--- a/.github/workflows/dev-pr-test.yml
+++ b/.github/workflows/dev-pr-test.yml
@@ -25,6 +25,7 @@ jobs:
         run: |
           touch src/main/resources/application.properties
           echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
       - name: Test with Gradle
         run: |
           chmod +x gradlew

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -31,6 +31,7 @@ jobs:
         run: |
           touch src/main/resources/application.properties
           echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
 
       - name: Build with Gradle
         run: |

--- a/.github/workflows/release-production-ci.yml
+++ b/.github/workflows/release-production-ci.yml
@@ -36,6 +36,7 @@ jobs:
       run: |
         touch src/main/resources/application.properties
         echo "${{ secrets.APPLICATION_PROPERTIES_PRODUCTION }}" > src/main/resources/application.properties
+        echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
      
     - name: Build with Gradle
       run: |

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
@@ -30,9 +30,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
                 .join(history.rentStoreMeta, storeMeta).fetchJoin()
                 .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(filterRefunded(filter))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
+                .orderBy(history.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -43,15 +41,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
 
         return queryFactory
                 .selectFrom(history)
-                .join(history.user, user).fetchJoin()
-                .leftJoin(history.refundedBy, user).fetchJoin()
-                .join(history.umbrella, umbrella).fetchJoin()
-                .join(history.rentStoreMeta, storeMeta).fetchJoin()
-                .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(filterRefunded(filter))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
                 .fetchCount();
     }
 
@@ -66,9 +56,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
                 .join(history.rentStoreMeta, storeMeta).fetchJoin()
                 .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
                 .where(history.user.id.eq(userId))
-                .orderBy(history.refundedAt.desc().nullsFirst(),
-                        history.returnedAt.desc().nullsFirst(),
-                        history.id.desc())
+                .orderBy(history.id.desc())
                 .fetch();
     }
 

--- a/src/main/java/upbrella/be/rent/service/ConditionReportService.java
+++ b/src/main/java/upbrella/be/rent/service/ConditionReportService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.rent.dto.response.ConditionReportPageResponse;
 import upbrella.be.rent.dto.response.ConditionReportResponse;
+import upbrella.be.rent.entity.ConditionReport;
 import upbrella.be.rent.repository.ConditionReportRepository;
 
 import java.util.List;
@@ -19,6 +20,11 @@ public class ConditionReportService {
     public ConditionReportPageResponse findAll() {
 
         return ConditionReportPageResponse.of(findAllConditionReport());
+    }
+
+    public void saveConditionReport(ConditionReport conditionReport) {
+
+        conditionReportRepository.save(conditionReport);
     }
 
     private List<ConditionReportResponse> findAllConditionReport() {

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -27,8 +27,8 @@ public class StoreController {
     private final ClassificationService classificationService;
     private final StoreDetailService storeDetailService;
 
-    @GetMapping("/stores/{storeDetailId}")
-    public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(@PathVariable long storeDetailId) {
+    @GetMapping("/stores/{storeId}")
+    public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(@PathVariable long storeId) {
 
         return ResponseEntity
                 .ok()
@@ -36,7 +36,7 @@ public class StoreController {
                         "success",
                         200,
                         "가게 조회 성공",
-                        storeDetailService.findStoreDetailByStoreMetaId(storeDetailId)));
+                        storeDetailService.findStoreDetailByStoreId(storeId)));
     }
 
     @GetMapping("/stores/classification/{classificationId}")

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreIntroductionResponse.java
@@ -35,7 +35,7 @@ public class SingleStoreIntroductionResponse {
         String thumbnail = createThumbnail(sortedImageUrls);
         StoreMeta storeMeta = storeDetail.getStoreMeta();
 
-        return of(storeDetail.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
+        return of(storeMeta.getId(), thumbnail, storeMeta.getName(), storeMeta.getCategory());
     }
 
     private static String createThumbnail(List<SingleImageUrlResponse> imageUrls) {

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -34,7 +34,7 @@ public class SingleStoreResponse {
     public static SingleStoreResponse ofCreateSingleStoreResponse(StoreDetail storeDetail, String thumbnail, List<SingleImageUrlResponse> images, List<SingleBusinessHourResponse> businessHours) {
 
         return SingleStoreResponse.builder()
-                .id(storeDetail.getId())
+                .id(storeDetail.getStoreMeta().getId())
                 .name(storeDetail.getStoreMeta().getName())
                 .category(storeDetail.getStoreMeta().getCategory())
                 .classification(SingleClassificationResponse.ofCreateClassification(storeDetail.getStoreMeta().getClassification()))

--- a/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/StoreFindByIdResponse.java
@@ -31,7 +31,7 @@ public class StoreFindByIdResponse {
     public static StoreFindByIdResponse fromStoreDetail(StoreDetail storeDetail, long availableUmbrellaCount) {
 
         return StoreFindByIdResponse.builder()
-                .id(storeDetail.getId())
+                .id(storeDetail.getStoreMeta().getId())
                 .name(storeDetail.getStoreMeta().getName())
                 .businessHours(storeDetail.getWorkingHour())
                 .contactNumber(storeDetail.getContactInfo())

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -29,7 +29,7 @@ public class StoreDetailService {
     @Transactional
     public void updateStore(Long storeId, UpdateStoreRequest request) {
 
-        StoreDetail storeDetailById = findStoreDetailById(storeId);
+        StoreDetail storeDetailById = findStoreDetailByStoreMetaId(storeId);
         long storeMetaId = storeDetailById.getStoreMeta().getId();
 
         Classification classification = classificationService.findClassificationById(request.getClassificationId());
@@ -46,19 +46,18 @@ public class StoreDetailService {
     }
 
     @Transactional(readOnly = true)
-    public StoreDetail findStoreDetailById(Long storeId) {
+    public StoreDetail findStoreDetailByStoreMetaId(Long storeId) {
 
-        return storeDetailRepository.findById(storeId)
+        return storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeId)
                 .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 존재하지 않는 가게입니다."));
     }
 
     @Transactional
-    public StoreFindByIdResponse findStoreDetailByStoreMetaId(long storeDetailId) {
+    public StoreFindByIdResponse findStoreDetailByStoreId(long storeId) {
 
-        StoreDetail storeDetail = findStoreDetailById(storeDetailId);
-        long storeMetaId = storeDetail.getStoreMeta().getId();
+        StoreDetail storeDetail = findStoreDetailByStoreMetaId(storeId);
 
-        long availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeMetaId);
+        long availableUmbrellaCount = umbrellaService.countAvailableUmbrellaAtStore(storeId);
 
         return StoreFindByIdResponse.fromStoreDetail(storeDetail, availableUmbrellaCount);
     }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -91,10 +91,9 @@ public class StoreMetaService {
     }
 
     @Transactional
-    public void deleteStoreMeta(long storeDetailId) {
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeDetailId);
+    public void deleteStoreMeta(long storeMetaId) {
 
-        findStoreMetaById(storeDetail.getStoreMeta().getId()).delete();
+        findStoreMetaById(storeMetaId).delete();
     }
 
     @Transactional(readOnly = true)
@@ -140,7 +139,7 @@ public class StoreMetaService {
     @Transactional
     public void activateStoreStatus(long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         Set<StoreImage> storeImages = storeDetail.getStoreImages();
         if (storeImages == null || storeImages.isEmpty()) {
@@ -153,7 +152,7 @@ public class StoreMetaService {
     @Transactional
     public void inactivateStoreStatus(long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         storeDetail.getStoreMeta().inactivateStoreStatus();
     }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -12,6 +12,7 @@ public class UmbrellaResponse {
     private long storeMetaId;
     private long uuid;
     private boolean rentable;
+    private String etc;
 
     public static UmbrellaResponse fromUmbrella(Umbrella umbrella) {
         return UmbrellaResponse.builder()
@@ -19,6 +20,7 @@ public class UmbrellaResponse {
                 .rentable(umbrella.isRentable())
                 .storeMetaId(umbrella.getStoreMeta().getId())
                 .uuid(umbrella.getUuid())
+                .etc(umbrella.getEtc())
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaResponse.java
@@ -2,25 +2,29 @@ package upbrella.be.umbrella.dto.response;
 
 import lombok.Builder;
 import lombok.Getter;
-import upbrella.be.umbrella.entity.Umbrella;
 
 @Getter
 @Builder
 public class UmbrellaResponse {
 
     private long id;
+    private Long historyId;
     private long storeMetaId;
+    private String storeName;
     private long uuid;
     private boolean rentable;
     private String etc;
 
-    public static UmbrellaResponse fromUmbrella(Umbrella umbrella) {
+    public static UmbrellaResponse fromUmbrella(UmbrellaWithHistory umbrellaWithHistory) {
+
         return UmbrellaResponse.builder()
-                .id(umbrella.getId())
-                .rentable(umbrella.isRentable())
-                .storeMetaId(umbrella.getStoreMeta().getId())
-                .uuid(umbrella.getUuid())
-                .etc(umbrella.getEtc())
+                .id(umbrellaWithHistory.getId())
+                .historyId(umbrellaWithHistory.getHistoryId())
+                .rentable(umbrellaWithHistory.isRentable())
+                .storeMetaId(umbrellaWithHistory.getStoreMeta().getId())
+                .storeName(umbrellaWithHistory.getStoreMeta().getName())
+                .uuid(umbrellaWithHistory.getUuid())
+                .etc(umbrellaWithHistory.getEtc())
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
@@ -1,0 +1,40 @@
+package upbrella.be.umbrella.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import upbrella.be.store.entity.StoreMeta;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class UmbrellaWithHistory {
+
+    private long id;
+    private StoreMeta storeMeta;
+    private long uuid;
+    private boolean rentable;
+    private boolean deleted;
+    private LocalDateTime createdAt;
+    private String etc;
+    private boolean missed;
+    private Long historyId;
+
+    @QueryProjection
+    public UmbrellaWithHistory(long id, StoreMeta storeMeta, long uuid, boolean rentable, boolean deleted, LocalDateTime createdAt, String etc, boolean missed, Long historyId) {
+
+        this.id = id;
+        this.storeMeta = storeMeta;
+        this.uuid = uuid;
+        this.rentable = rentable;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+        this.etc = etc;
+        this.missed = missed;
+        this.historyId = historyId;
+    }
+}
+

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepository.java
@@ -11,13 +11,7 @@ public interface UmbrellaRepository extends JpaRepository<Umbrella, Long>, Umbre
 
     Optional<Umbrella> findByIdAndDeletedIsFalse(long id);
 
-    boolean existsByIdAndDeletedIsFalse(long id);
-
     boolean existsByUuidAndDeletedIsFalse(long uuid);
 
     List<Umbrella> findByDeletedIsFalseOrderById(Pageable pageable);
-
-    List<Umbrella> findByStoreMetaIdAndDeletedIsFalseOrderById(long storeMetaId, Pageable pageable);
-
-
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryCustom.java
@@ -1,5 +1,10 @@
 package upbrella.be.umbrella.repository;
 
+import org.springframework.data.domain.Pageable;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
+
+import java.util.List;
+
 public interface UmbrellaRepositoryCustom {
 
     long countAllUmbrellas();
@@ -17,4 +22,8 @@ public interface UmbrellaRepositoryCustom {
     long countAllUmbrellasByStore(long storeId);
 
     long countMissingUmbrellasByStore(long storeId);
+
+    List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaId(Pageable pageable);
+
+    List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(long storeId, Pageable pageable);
 }

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
@@ -2,7 +2,13 @@ package upbrella.be.umbrella.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import upbrella.be.umbrella.dto.response.QUmbrellaWithHistory;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 
+import java.util.List;
+
+import static upbrella.be.rent.entity.QHistory.history;
 import static upbrella.be.umbrella.entity.QUmbrella.umbrella;
 
 @RequiredArgsConstructor
@@ -86,5 +92,60 @@ public class UmbrellaRepositoryImpl implements UmbrellaRepositoryCustom {
                         .and(umbrella.missed.eq(true))
                         .and(umbrella.deleted.eq(false)))
                 .fetchCount();
+    }
+
+    @Override
+    public List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaId(Pageable pageable) {
+
+        QUmbrellaWithHistory umbrellaWithHistory = new QUmbrellaWithHistory(
+                umbrella.id,
+                umbrella.storeMeta,
+                umbrella.uuid,
+                umbrella.rentable,
+                umbrella.deleted,
+                umbrella.createdAt,
+                umbrella.etc,
+                umbrella.missed,
+                history.id
+        );
+
+        return queryFactory.select(umbrellaWithHistory)
+                .from(history)
+                .rightJoin(history.umbrella, umbrella)
+                .join(umbrella.storeMeta)
+                .where(umbrella.deleted.eq(false)
+                        .and(history.returnedAt.isNull()))
+                .orderBy(umbrella.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+    }
+
+    @Override
+    public List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(long storeId, Pageable pageable) {
+
+        QUmbrellaWithHistory umbrellaWithHistory = new QUmbrellaWithHistory(
+                umbrella.id,
+                umbrella.storeMeta,
+                umbrella.uuid,
+                umbrella.rentable,
+                umbrella.deleted,
+                umbrella.createdAt,
+                umbrella.etc,
+                umbrella.missed,
+                history.id
+        );
+
+        return queryFactory.select(umbrellaWithHistory)
+                .from(history)
+                .rightJoin(history.umbrella, umbrella)
+                .join(umbrella.storeMeta)
+                .where(umbrella.deleted.eq(false)
+                        .and(umbrella.storeMeta.id.eq(storeId))
+                        .and(history.returnedAt.isNull()))
+                .orderBy(umbrella.id.asc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
     }
 }

--- a/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
+++ b/src/main/java/upbrella/be/umbrella/service/UmbrellaService.java
@@ -34,14 +34,14 @@ public class UmbrellaService {
 
     public List<UmbrellaResponse> findAllUmbrellas(Pageable pageable) {
 
-        return umbrellaRepository.findByDeletedIsFalseOrderById(pageable)
+        return umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable)
                 .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toList());
     }
 
     public List<UmbrellaResponse> findUmbrellasByStoreId(long storeId, Pageable pageable) {
 
-        return umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(storeId, pageable)
+        return umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(storeId, pageable)
                 .stream().map(UmbrellaResponse::fromUmbrella)
                 .collect(Collectors.toList());
     }

--- a/src/main/java/upbrella/be/user/controller/UserController.java
+++ b/src/main/java/upbrella/be/user/controller/UserController.java
@@ -163,7 +163,7 @@ public class UserController {
     }
 
     @GetMapping("/users/histories")
-    public ResponseEntity<CustomResponse> readUserHistories(HttpSession session) {
+    public ResponseEntity<CustomResponse<AllHistoryResponse>> readUserHistories(HttpSession session) {
 
         SessionUser sessionUser = (SessionUser) session.getAttribute("user");
 

--- a/src/main/java/upbrella/be/user/dto/response/SingleBlackListResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/SingleBlackListResponse.java
@@ -12,7 +12,6 @@ import java.time.LocalDateTime;
 public class SingleBlackListResponse {
 
     private long id;
-    private long socialId;
     @JsonFormat(shape= JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd kk:mm:ss")
     private LocalDateTime blockedAt;
 
@@ -20,7 +19,6 @@ public class SingleBlackListResponse {
 
         return SingleBlackListResponse.builder()
                 .id(blackList.getId())
-                .socialId(blackList.getSocialId())
                 .blockedAt(blackList.getBlockedAt())
                 .build();
     }

--- a/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
+++ b/src/main/java/upbrella/be/user/dto/response/SingleUserInfoResponse.java
@@ -9,7 +9,6 @@ import upbrella.be.user.entity.User;
 public class SingleUserInfoResponse {
 
     private long id;
-    private long socialId;
     private String name;
     private String phoneNumber;
     private String email;
@@ -21,7 +20,6 @@ public class SingleUserInfoResponse {
 
         return SingleUserInfoResponse.builder()
                 .id(user.getId())
-                .socialId(user.getSocialId())
                 .name(user.getName())
                 .phoneNumber(user.getPhoneNumber())
                 .email(user.getEmail())

--- a/src/main/java/upbrella/be/user/service/UserService.java
+++ b/src/main/java/upbrella/be/user/service/UserService.java
@@ -98,6 +98,10 @@ public class UserService {
 
         User foundUser = findUserById(id);
         Long socialId = foundUser.getSocialId();
+
+        if (socialId == 0L) {
+            throw new NonExistingMemberException("[ERROR] 탈퇴하였거나 이미 블랙리스트 처리된 회원입니다.");
+        }
         BlackList newBlackList = BlackList.createNewBlackList(socialId);
         blackListRepository.save(newBlackList);
 

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -108,7 +108,8 @@ public class FixtureBuilderFactory {
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", buildLong(10000))
                 .set("storeMetaId", buildLong(100))
-                .set("uuid", buildLong(100));
+                .set("uuid", buildLong(100))
+                .set("etc", "etc");
     }
 
     public static ArbitraryBuilder<UmbrellaCreateRequest> builderUmbrellaCreateRequest() {

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -12,6 +12,7 @@ import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.request.UpdateBankAccountRequest;
@@ -103,12 +104,25 @@ public class FixtureBuilderFactory {
                 .set("etc", pickRandomString(nameList));
     }
 
+    public static ArbitraryBuilder<UmbrellaWithHistory> builderUmbrellaWithHistory() {
+
+        return fixtureMonkey.giveMeBuilder(UmbrellaWithHistory.class)
+                .set("id", buildLong(10000))
+                .set("uuid", buildLong(1000))
+                .set("historyId", buildLong(1000))
+                .set("storeMeta", builderStoreMeta().sample())
+                .set("deleted", false)
+                .set("etc", pickRandomString(nameList));
+    }
+
     public static ArbitraryBuilder<UmbrellaResponse> builderUmbrellaResponses() {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", buildLong(10000))
                 .set("storeMetaId", buildLong(100))
+                .set("historyId", buildLong(100))
                 .set("uuid", buildLong(100))
+                .set("storeName", pickRandomString(cafeList))
                 .set("etc", "etc");
     }
 

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -60,6 +60,7 @@ public class FixtureFactory {
                 .set("storeMetaId", storeMeta.getId())
                 .set("uuid", umbrella.getUuid())
                 .set("rentable", umbrella.isRentable())
+                .set("etc", umbrella.getEtc())
                 .sample();
     }
 

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -8,6 +8,7 @@ import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.user.dto.request.JoinRequest;
 import upbrella.be.user.dto.response.KakaoLoginResponse;
@@ -53,13 +54,15 @@ public class FixtureFactory {
                 .sample();
     }
 
-    public static UmbrellaResponse buildUmbrellaResponseWithUmbrellaAndStoreMeta(Umbrella umbrella, StoreMeta storeMeta) {
+    public static UmbrellaResponse buildUmbrellaResponseWithUmbrellaAndStoreMeta(UmbrellaWithHistory umbrella, StoreMeta storeMeta) {
 
         return fixtureMonkey.giveMeBuilder(UmbrellaResponse.class)
                 .set("id", umbrella.getId())
                 .set("storeMetaId", storeMeta.getId())
                 .set("uuid", umbrella.getUuid())
                 .set("rentable", umbrella.isRentable())
+                .set("storeName", storeMeta.getName())
+                .set("historyId", umbrella.getHistoryId())
                 .set("etc", umbrella.getEtc())
                 .sample();
     }

--- a/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
+++ b/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
@@ -1,20 +1,16 @@
-package upbrella.be.config;
+package upbrella.be.config.interceptor;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
-import upbrella.be.config.interceptor.AdminInterceptor;
-import upbrella.be.config.interceptor.LoginInterceptor;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
 
 @Configuration
 @RequiredArgsConstructor
-@Profile("!test")
-public class AuthConfig implements WebMvcConfigurer {
+public class AuthTestConfig implements WebMvcConfigurer {
 
     private final LoginInterceptor loginInterceptor;
     private final AdminInterceptor adminInterceptor;
@@ -25,6 +21,8 @@ public class AuthConfig implements WebMvcConfigurer {
                 .order(HIGHEST_PRECEDENCE)
                 .addPathPatterns("/**")
                 .excludePathPatterns(
+                        "/oauth/token",
+                        "/user/me",
                         "/users/login/**",
                         "/users/oauth/login/**",
                         "/users/join/**",
@@ -39,6 +37,8 @@ public class AuthConfig implements WebMvcConfigurer {
                 .order(LOWEST_PRECEDENCE)
                 .addPathPatterns("/admin/**")
                 .excludePathPatterns(
+                        "/oauth/token",
+                        "/user/me",
                         "/users/login/**",
                         "/users/oauth/login/**",
                         "/users/join/**",

--- a/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
+++ b/src/test/java/upbrella/be/config/interceptor/AuthTestConfig.java
@@ -1,19 +1,23 @@
 package upbrella.be.config.interceptor;
 
-import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import static org.springframework.core.Ordered.HIGHEST_PRECEDENCE;
 import static org.springframework.core.Ordered.LOWEST_PRECEDENCE;
 
+@Profile("test")
 @Configuration
-@RequiredArgsConstructor
-public class AuthTestConfig implements WebMvcConfigurer {
+public class AuthTestConfig implements WebMvcConfigurer  {
 
-    private final LoginInterceptor loginInterceptor;
-    private final AdminInterceptor adminInterceptor;
+    @Autowired
+    private LoginInterceptor loginInterceptor;
+    @Autowired
+    private AdminInterceptor adminInterceptor;
+
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -77,7 +77,7 @@ class StoreControllerTest extends RestDocsSupport {
                         "https://upbrella-store-image.s3.ap-northeast-2.amazonaws.com/3.jpg"))
                 .build();
 
-        given(storeDetailService.findStoreDetailByStoreMetaId(2L))
+        given(storeDetailService.findStoreDetailByStoreId(2L))
                 .willReturn(storeFindByIdResponse);
 
         // when & then

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -94,14 +94,14 @@ public class StoreDetailServiceTest {
 
             // given
 
-            given(storeDetailRepository.findById(3L))
+            given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(3L))
                     .willReturn(Optional.of(storeDetail));
 
             given(umbrellaService.countAvailableUmbrellaAtStore(3L))
                     .willReturn(10L);
 
             //when
-            StoreFindByIdResponse storeFindByIdResponse = storeDetailService.findStoreDetailByStoreMetaId(3L);
+            StoreFindByIdResponse storeFindByIdResponse = storeDetailService.findStoreDetailByStoreId(3L);
 
             //then
             assertAll(
@@ -109,7 +109,7 @@ public class StoreDetailServiceTest {
                             .usingRecursiveComparison()
                             .isEqualTo(storeFindByIdResponseExpected),
                     () -> then(storeDetailRepository).should(times(1))
-                            .findById(3L),
+                            .findByStoreMetaIdUsingFetchJoin(3L),
                     () -> then(umbrellaService).should(times(1))
                             .countAvailableUmbrellaAtStore(3L)
             );
@@ -361,11 +361,11 @@ public class StoreDetailServiceTest {
         @DisplayName("id로 조회할 수 있다.")
         void findByIdTest() {
             // given
-            long storeDetailId = 1L;
-            given(storeDetailRepository.findById(storeDetailId)).willReturn(Optional.of(storeDetail));
+            long storeMetaId = 1L;
+            given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeMetaId)).willReturn(Optional.of(storeDetail));
 
             // when
-            StoreDetail storeDetailById = storeDetailService.findStoreDetailById(storeDetailId);
+            StoreDetail storeDetailById = storeDetailService.findStoreDetailByStoreMetaId(storeMetaId);
 
             // then
             assertAll(
@@ -386,7 +386,7 @@ public class StoreDetailServiceTest {
 
 
             // then
-            assertThatThrownBy(() -> storeDetailService.findStoreDetailById(storeDetailId))
+            assertThatThrownBy(() -> storeDetailService.findStoreDetailByStoreMetaId(storeDetailId))
                     .isInstanceOf(NonExistingStoreDetailException.class)
                     .hasMessageContaining("[ERROR] 존재하지 않는 가게입니다.");
         }
@@ -563,7 +563,7 @@ public class StoreDetailServiceTest {
                 .build();
 
 
-        given(storeDetailRepository.findById(storeId)).willReturn(Optional.of(storedetail));
+        given(storeDetailRepository.findByStoreMetaIdUsingFetchJoin(storeId)).willReturn(Optional.of(storedetail));
         given(classificationService.findClassificationById(request.getClassificationId())).willReturn(classificationUpdate);
         given(classificationService.findSubClassificationById(request.getSubClassificationId())).willReturn(subClassificationUpdate);
         given(storeMetaService.findStoreMetaById(storeId)).willReturn(storeMeta);
@@ -576,7 +576,7 @@ public class StoreDetailServiceTest {
         StoreMeta foundStoreMeta = storeMetaService.findStoreMetaById(storeId);
 
 
-        StoreDetail foundStoreDetail = storeDetailService.findStoreDetailById(storeId);
+        StoreDetail foundStoreDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         assertAll(
                 () -> assertThat(foundStoreMeta) // 업데이트된 필드에 대한 검증
@@ -630,7 +630,7 @@ public class StoreDetailServiceTest {
         StoreIntroductionsResponseByClassification storeIntroductionsResponseByClassification = StoreIntroductionsResponseByClassification
                 .builder()
                 .subClassificationId(1)
-                .stores(List.of(SingleStoreIntroductionResponse.of(2L, "가게 썸네일", "스타벅스", "카페, 디저트")))
+                .stores(List.of(SingleStoreIntroductionResponse.of(3L, "가게 썸네일", "스타벅스", "카페, 디저트")))
                 .build();
 
         AllStoreIntroductionResponse expected = AllStoreIntroductionResponse.builder()

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -466,7 +466,6 @@ class StoreMetaServiceTest {
                 .id(1L)
                 .storeMeta(storeMeta).build();
 
-        given(storeDetailService.findStoreDetailById(anyLong())).willReturn(storeDetail);
         given(storeMetaRepository.findById(1L)).willReturn(Optional.of(storeMeta));
 
         // when
@@ -572,7 +571,7 @@ class StoreMetaServiceTest {
                 .build();
 
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
         storeMetaService.activateStoreStatus(1L);
@@ -595,7 +594,7 @@ class StoreMetaServiceTest {
                 .storeImages(Set.of())
                 .build();
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
 
@@ -623,7 +622,7 @@ class StoreMetaServiceTest {
                 .build();
 
 
-        given(storeDetailService.findStoreDetailById(1L)).willReturn(storeDetail);
+        given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
 
         // when
         storeMetaService.inactivateStoreStatus(1L);

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -93,7 +93,9 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)
-                                        .description("대여 가능 상태")
+                                        .description("대여 가능 상태"),
+                                fieldWithPath("umbrellaResponsePage[].etc").type(JsonFieldType.STRING)
+                                        .description("기타 특이 사항")
                         )));
     }
 
@@ -142,7 +144,9 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)
-                                        .description("대여 가능 상태")
+                                        .description("대여 가능 상태"),
+                                fieldWithPath("umbrellaResponsePage[].etc").type(JsonFieldType.STRING)
+                                        .description("기타 특이 사항")
                         )));
     }
 

--- a/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
+++ b/src/test/java/upbrella/be/umbrella/controller/UmbrellaControllerTest.java
@@ -88,8 +88,13 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                         .description("우산 목록"),
                                 fieldWithPath("umbrellaResponsePage[].id").type(JsonFieldType.NUMBER)
                                         .description("우산 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].historyId").type(JsonFieldType.NUMBER)
+                                        .description("현재 대여 내역 고유번호")
+                                        .optional(),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
                                         .description("보관 지점 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)
+                                        .description("보관 지점 이름"),
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)
@@ -139,8 +144,13 @@ public class UmbrellaControllerTest extends RestDocsSupport {
                                         .description("우산 목록"),
                                 fieldWithPath("umbrellaResponsePage[].id").type(JsonFieldType.NUMBER)
                                         .description("우산 고유번호"),
+                                fieldWithPath("umbrellaResponsePage[].historyId").type(JsonFieldType.NUMBER)
+                                        .description("현재 대여 내역 고유번호")
+                                        .optional(),
                                 fieldWithPath("umbrellaResponsePage[].storeMetaId").type(JsonFieldType.NUMBER)
-                                        .description("보관 지점번호"),
+                                        .description("보관 지점 고유 번호"),
+                                fieldWithPath("umbrellaResponsePage[].storeName").type(JsonFieldType.STRING)
+                                        .description("보관 지점 이름"),
                                 fieldWithPath("umbrellaResponsePage[].uuid").type(JsonFieldType.NUMBER)
                                         .description("우산 관리번호"),
                                 fieldWithPath("umbrellaResponsePage[].rentable").type(JsonFieldType.BOOLEAN)

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -123,6 +123,7 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
 
         // given
         UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
+                .set("id", 999L)
                 .set("storeMetaId", storeMeta.getId())
                 .sample();
 

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -125,6 +125,7 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
         UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
                 .set("id", 999L)
                 .set("storeMetaId", storeMeta.getId())
+                .set("uuid", 3000L)
                 .sample();
 
         // when & then
@@ -192,6 +193,7 @@ public class UmbrellaIntegrationTest extends RestDocsSupport {
         long id = umbrellaList.get(0).getId();
         UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
                 .set("storeMetaId", storeMeta.getId())
+                .set("uuid", 2000L)
                 .sample();
 
         // when & then

--- a/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
+++ b/src/test/java/upbrella/be/umbrella/integration/UmbrellaIntegrationTest.java
@@ -1,0 +1,277 @@
+package upbrella.be.umbrella.integration;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.transaction.annotation.Transactional;
+import upbrella.be.config.FixtureBuilderFactory;
+import upbrella.be.docs.utils.RestDocsSupport;
+import upbrella.be.store.entity.Classification;
+import upbrella.be.store.entity.ClassificationType;
+import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.umbrella.controller.UmbrellaController;
+import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
+import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
+import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.umbrella.service.UmbrellaService;
+
+import javax.persistence.EntityManager;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@Transactional
+@SpringBootTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+public class UmbrellaIntegrationTest extends RestDocsSupport {
+
+    @Autowired
+    private UmbrellaService umbrellaService;
+    @Autowired
+    private EntityManager em;
+    private StoreMeta storeMeta;
+    private List<Umbrella> umbrellaList;
+
+    @Override
+    protected Object initController() {
+        return new UmbrellaController(umbrellaService);
+    }
+
+    @BeforeEach
+    void setUp() {
+
+        Classification classification = FixtureBuilderFactory.builderClassification()
+                .set("type", ClassificationType.CLASSIFICATION)
+                .set("id", null).sample();
+
+        Classification subClassification = FixtureBuilderFactory.builderClassification()
+                .set("type", ClassificationType.SUB_CLASSIFICATION)
+                .set("id", null).sample();
+
+        em.persist(classification);
+        em.persist(subClassification);
+        em.flush();
+
+        storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                .set("id", null)
+                .set("classification", classification)
+                .set("subClassification", subClassification)
+                .set("businessHours", null).sample();
+
+        em.persist(storeMeta);
+        em.flush();
+
+        // 대여 가능 우산 3개 생성
+        umbrellaList = new ArrayList<>();
+        for (int i = 0; i < 3; i++) {
+            Umbrella umbrella = FixtureBuilderFactory.builderUmbrella()
+                    .set("id", null)
+                    .set("storeMeta", storeMeta)
+                    .set("rentable", true)
+                    .set("deleted", false)
+                    .set("missed", false)
+                    .sample();
+
+            umbrellaList.add(umbrella);
+            em.persist(umbrella);
+            em.flush();
+        }
+
+        // 대여 중 우산 2개 생성
+        for (int i = 0; i < 2; i++) {
+            Umbrella umbrella = FixtureBuilderFactory.builderUmbrella()
+                    .set("id", null)
+                    .set("storeMeta", storeMeta)
+                    .set("rentable", false)
+                    .set("deleted", false)
+                    .set("missed", false)
+                    .sample();
+
+            umbrellaList.add(umbrella);
+            em.persist(umbrella);
+            em.flush();
+        }
+
+        // 분실 우산 1개 생성
+        for (int i = 0; i < 1; i++) {
+            Umbrella umbrella = FixtureBuilderFactory.builderUmbrella()
+                    .set("id", null)
+                    .set("storeMeta", storeMeta)
+                    .set("rentable", false)
+                    .set("deleted", false)
+                    .set("missed", true)
+                    .sample();
+
+            umbrellaList.add(umbrella);
+            em.persist(umbrella);
+            em.flush();
+        }
+    }
+
+    @Test
+    @DisplayName("관리자는 우산을 등록할 수 있다.")
+    void addUmbrellaTest() throws Exception {
+
+        // given
+        UmbrellaCreateRequest umbrellaCreateRequest = FixtureBuilderFactory.builderUmbrellaCreateRequest()
+                .set("storeMetaId", storeMeta.getId())
+                .sample();
+
+        // when & then
+        mockMvc.perform(
+                        post("/admin/umbrellas")
+                                .content(objectMapper.writeValueAsString(umbrellaCreateRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        get("/admin/umbrellas")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage").exists())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage.length()").value(umbrellaList.size() + 1))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[6].storeMetaId").value(umbrellaCreateRequest.getStoreMetaId()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[6].uuid").value(umbrellaCreateRequest.getUuid()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[6].rentable").value(umbrellaCreateRequest.isRentable()));
+    }
+
+
+    @Test
+    @DisplayName("사용자는 전체 우산 현황을 조회할 수 있다.")
+    void showAllUmbrellasTest() throws Exception {
+
+        // when & then
+        mockMvc.perform(
+                        get("/admin/umbrellas")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage").exists())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage.length()").value(6))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].storeMetaId").value(storeMeta.getId()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].uuid").value(umbrellaList.get(0).getUuid()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].rentable").value(umbrellaList.get(0).isRentable()));
+    }
+
+
+    @DisplayName("사용자는 지점 우산 현황을 조회할 수 있다.")
+    @Test
+    void showUmbrellasByStoreIdTest() throws Exception {
+
+        // when & then
+        mockMvc.perform(
+                        get("/admin/umbrellas/{storeId}", storeMeta.getId())
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage").exists())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage.length()").value(6))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].storeMetaId").value(storeMeta.getId()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].uuid").value(umbrellaList.get(0).getUuid()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].rentable").value(umbrellaList.get(0).isRentable()));
+        ;
+    }
+
+
+    @DisplayName("사용자는 우산 정보를 수정할 수 있다.")
+    @Test
+    void modifyUmbrellaTest() throws Exception {
+
+        // given
+        long id = umbrellaList.get(0).getId();
+        UmbrellaModifyRequest umbrellaModifyRequest = FixtureBuilderFactory.builderUmbrellaModifyRequest()
+                .set("storeMetaId", storeMeta.getId())
+                .sample();
+
+        // when & then
+        mockMvc.perform(
+                        patch("/admin/umbrellas/{umbrellaId}", id)
+                                .content(objectMapper.writeValueAsString(umbrellaModifyRequest))
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .accept(MediaType.APPLICATION_JSON)
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        get("/admin/umbrellas")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage").exists())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage.length()").value(umbrellaList.size()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].storeMetaId").value(umbrellaModifyRequest.getStoreMetaId()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].uuid").value(umbrellaModifyRequest.getUuid()))
+                .andExpect(jsonPath("$.data.umbrellaResponsePage[0].rentable").value(umbrellaModifyRequest.isRentable()));
+    }
+
+
+    @DisplayName("관리자는 우산 정보를 삭제할 수 있다.")
+    @Test
+    void deleteUmbrellaTest() throws Exception {
+
+        // given
+        long id = umbrellaList.get(0).getId();
+
+        // when & then
+        mockMvc.perform(
+                        delete("/admin/umbrellas/{umbrellaId}", id)
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        mockMvc.perform(
+                        get("/admin/umbrellas")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage").exists())
+                .andExpect(jsonPath("$.data.umbrellaResponsePage.length()").value(umbrellaList.size() - 1));
+    }
+
+
+    @DisplayName("관리자는 전체 우산 통계를 조회할 수 있다.")
+    @Test
+    void showAllUmbrellasStatisticsTest() throws Exception {
+
+        // when & then
+        mockMvc.perform(
+                        get("/admin/umbrellas/statistics")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.totalUmbrellaCount").value(6))
+                .andExpect(jsonPath("$.data.rentableUmbrellaCount").value(3))
+                .andExpect(jsonPath("$.data.rentedUmbrellaCount").value(2))
+                .andExpect(jsonPath("$.data.missingUmbrellaCount").value(1))
+                .andExpect(jsonPath("$.data.missingRate").value(16))
+                .andExpect(jsonPath("$.data.totalRentCount").value(0));
+
+    }
+
+
+    @DisplayName("관리자는 지점 우산 통계를 조회할 수 있다.")
+    @Test
+    void success() throws Exception {
+
+        // when & then
+        mockMvc.perform(
+                        get("/admin/umbrellas/statistics/{storeId}", storeMeta.getId())
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.totalUmbrellaCount").value(6))
+                .andExpect(jsonPath("$.data.rentableUmbrellaCount").value(3))
+                .andExpect(jsonPath("$.data.rentedUmbrellaCount").value(2))
+                .andExpect(jsonPath("$.data.missingUmbrellaCount").value(1))
+                .andExpect(jsonPath("$.data.missingRate").value(16))
+                .andExpect(jsonPath("$.data.totalRentCount").value(0));
+    }
+
+}

--- a/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
+++ b/src/test/java/upbrella/be/umbrella/service/UmbrellaServiceTest.java
@@ -20,6 +20,7 @@ import upbrella.be.umbrella.dto.request.UmbrellaCreateRequest;
 import upbrella.be.umbrella.dto.request.UmbrellaModifyRequest;
 import upbrella.be.umbrella.dto.response.UmbrellaResponse;
 import upbrella.be.umbrella.dto.response.UmbrellaStatisticsResponse;
+import upbrella.be.umbrella.dto.response.UmbrellaWithHistory;
 import upbrella.be.umbrella.entity.Umbrella;
 import upbrella.be.umbrella.exception.ExistingUmbrellaUuidException;
 import upbrella.be.umbrella.exception.NonExistingUmbrellaException;
@@ -57,6 +58,7 @@ class UmbrellaServiceTest {
         private StoreMeta storeMeta;
         private List<UmbrellaResponse> expectedUmbrellaResponses;
         private List<Umbrella> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellasWithHistory = new ArrayList<>();
 
         @BeforeEach
         void setUp() {
@@ -67,9 +69,13 @@ class UmbrellaServiceTest {
                 generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrella()
                         .set("storeMeta", storeMeta)
                         .sample());
+
+                generatedUmbrellasWithHistory.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
+                        .set("storeMeta", storeMeta)
+                        .sample());
             }
 
-            expectedUmbrellaResponses = generatedUmbrellas.stream()
+            expectedUmbrellaResponses = generatedUmbrellasWithHistory.stream()
                     .map(umbrella -> FixtureFactory.buildUmbrellaResponseWithUmbrellaAndStoreMeta(umbrella, storeMeta))
                     .collect(Collectors.toList());
         }
@@ -80,8 +86,8 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
-                    .willReturn(generatedUmbrellas);
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable))
+                    .willReturn(generatedUmbrellasWithHistory);
 
             //when
             List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findAllUmbrellas(pageable);
@@ -102,7 +108,7 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByDeletedIsFalseOrderById(pageable))
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaId(pageable))
                     .willReturn(List.of());
 
             //when
@@ -118,7 +124,8 @@ class UmbrellaServiceTest {
     class findUmbrellasByStoreIdTest {
         private StoreMeta storeMeta;
         private List<UmbrellaResponse> expectedUmbrellaResponses;
-        private List<Umbrella> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellas = new ArrayList<>();
+        private List<UmbrellaWithHistory> generatedUmbrellasWithHistory = new ArrayList<>();
 
         @BeforeEach
         void setUp() {
@@ -126,12 +133,15 @@ class UmbrellaServiceTest {
             storeMeta = FixtureBuilderFactory.builderStoreMeta().sample();
 
             for (int i = 0; i < 5; i++) {
-                generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrella()
+                generatedUmbrellas.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
+                        .set("storeMeta", storeMeta)
+                        .sample());
+                generatedUmbrellasWithHistory.add(FixtureBuilderFactory.builderUmbrellaWithHistory()
                         .set("storeMeta", storeMeta)
                         .sample());
             }
 
-            expectedUmbrellaResponses = generatedUmbrellas.stream()
+            expectedUmbrellaResponses = generatedUmbrellasWithHistory.stream()
                     .map(umbrella -> FixtureFactory.buildUmbrellaResponseWithUmbrellaAndStoreMeta(umbrella, storeMeta))
                     .collect(Collectors.toList());
         }
@@ -141,8 +151,8 @@ class UmbrellaServiceTest {
         void success() {
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
-                    .willReturn(generatedUmbrellas);
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(2L, pageable))
+                    .willReturn(generatedUmbrellasWithHistory);
 
             //when
             List<UmbrellaResponse> umbrellaResponseList = umbrellaService.findUmbrellasByStoreId(2L, pageable);
@@ -163,7 +173,7 @@ class UmbrellaServiceTest {
 
             //given
             Pageable pageable = PageRequest.of(0, 5);
-            given(umbrellaRepository.findByStoreMetaIdAndDeletedIsFalseOrderById(2L, pageable))
+            given(umbrellaRepository.findUmbrellaAndHistoryOrderedByUmbrellaIdByStoreId(2L, pageable))
                     .willReturn(List.of());
 
             //when

--- a/src/test/java/upbrella/be/user/controller/UserControllerTest.java
+++ b/src/test/java/upbrella/be/user/controller/UserControllerTest.java
@@ -232,44 +232,45 @@ public class UserControllerTest extends RestDocsSupport {
                             assertThat(result.getResolvedException())
                                     .isInstanceOf(InvalidLoginCodeException.class));
         }
-
-        @Test
-        @DisplayName("회원인 경우 로그인이 진행된다.")
-        void upbrellaLoginTest() throws Exception {
-            // given
-
-            KakaoLoginResponse kakaoUser = KakaoLoginResponse.builder()
-                    .id(1L)
-                    .kakaoAccount(
-                            KakaoAccount.builder()
-                                    .email("email@email.com")
-                                    .build())
-                    .build();
-
-            MockHttpSession session = new MockHttpSession();
-
-            SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
-            session.setAttribute("kakaoUser", kakaoUser);
-            given(userService.login(any())).willReturn(sessionUser);
-
-            // when
-
-            // then
-            mockMvc.perform(
-                            post("/users/login")
-                                    .session(session)
-                    ).andDo(print())
-                    .andExpect(status().isOk())
-                    .andDo(document("user-upbrella-login-doc",
-                            getDocumentRequest(),
-                            getDocumentResponse()
-                    ));
-        }
     }
 
     @Test
+    @DisplayName("사용자는 소셜 로그인 상태에서 업브렐라 로그인을 할 수 있다.")
+    void upbrellaLoginTest() throws Exception {
+        // given
+
+        KakaoLoginResponse kakaoUser = KakaoLoginResponse.builder()
+                .id(1L)
+                .kakaoAccount(
+                        KakaoAccount.builder()
+                                .email("email@email.com")
+                                .build())
+                .build();
+
+        MockHttpSession session = new MockHttpSession();
+
+        SessionUser sessionUser = FixtureBuilderFactory.builderSessionUser().sample();
+        session.setAttribute("kakaoUser", kakaoUser);
+        given(userService.login(any())).willReturn(sessionUser);
+
+        // when
+
+        // then
+        mockMvc.perform(
+                        post("/users/login")
+                                .session(session)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("user-upbrella-login-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse()
+                ));
+    }
+
+
+    @Test
     @DisplayName("사용자는 로그아웃을 할 수 있다.")
-    void loginSuccess() throws Exception {
+    void logoutTest() throws Exception {
 
         // given
         MockHttpSession mockHttpSession = new MockHttpSession();
@@ -458,8 +459,6 @@ public class UserControllerTest extends RestDocsSupport {
                                         .description("회원 정보 목록"),
                                 fieldWithPath("users[].id").type(JsonFieldType.NUMBER)
                                         .description("사용자 고유번호"),
-                                fieldWithPath("users[].socialId").type(JsonFieldType.NUMBER)
-                                        .description("사용자 소셜 고유번호"),
                                 fieldWithPath("users[].name").type(JsonFieldType.STRING)
                                         .description("사용자 이름"),
                                 fieldWithPath("users[].phoneNumber").type(JsonFieldType.STRING)
@@ -633,7 +632,6 @@ public class UserControllerTest extends RestDocsSupport {
         AllBlackListResponse blackLists = AllBlackListResponse.builder()
                 .blackList(List.of(SingleBlackListResponse.builder()
                         .id(1L)
-                        .socialId(1L)
                         .blockedAt(LocalDateTime.now())
                         .build()))
                 .build();
@@ -656,8 +654,6 @@ public class UserControllerTest extends RestDocsSupport {
                                         .description("블랙리스트 목록"),
                                 fieldWithPath("blackList[].id").type(JsonFieldType.NUMBER)
                                         .description("블랙리스트 고유번호"),
-                                fieldWithPath("blackList[].socialId").type(JsonFieldType.NUMBER)
-                                        .description("블랙리스트 소셜 고유번호"),
                                 fieldWithPath("blackList[].blockedAt")
                                         .description("블랙리스트 등록 날짜")
                         )));

--- a/src/test/java/upbrella/be/user/integration/MockKakaoServerController.java
+++ b/src/test/java/upbrella/be/user/integration/MockKakaoServerController.java
@@ -1,0 +1,43 @@
+package upbrella.be.user.integration;
+
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+import upbrella.be.user.dto.request.KakaoAccount;
+import upbrella.be.user.dto.response.KakaoLoginResponse;
+import upbrella.be.user.dto.token.OauthToken;
+
+@RestController
+public class MockKakaoServerController {
+
+    @PostMapping(path = "/oauth/token")
+    public ResponseEntity<OauthToken> getAccessToken(HttpEntity<String> request) {
+
+        OauthToken response = OauthToken.builder()
+                .accessToken("access_token")
+                .refreshToken("refresh_token")
+                .tokenType("bearer")
+                .expiresIn(3600L)
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping(path = "/user/me", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<KakaoLoginResponse> getMemberInfo(@RequestHeader(HttpHeaders.AUTHORIZATION) String token) {
+
+        KakaoLoginResponse response = KakaoLoginResponse.builder()
+                .id(1L)
+                .kakaoAccount(KakaoAccount.builder()
+                        .email("email@email.com")
+                        .build())
+                .build();
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/test/java/upbrella/be/user/integration/UserIntegrationTest.java
+++ b/src/test/java/upbrella/be/user/integration/UserIntegrationTest.java
@@ -1,0 +1,469 @@
+package upbrella.be.user.integration;
+
+import org.junit.jupiter.api.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpSession;
+import org.springframework.transaction.annotation.Transactional;
+import upbrella.be.config.FixtureBuilderFactory;
+import upbrella.be.docs.utils.RestDocsSupport;
+import upbrella.be.rent.entity.History;
+import upbrella.be.rent.service.RentService;
+import upbrella.be.store.entity.Classification;
+import upbrella.be.store.entity.ClassificationType;
+import upbrella.be.store.entity.StoreMeta;
+import upbrella.be.umbrella.entity.Umbrella;
+import upbrella.be.user.controller.UserController;
+import upbrella.be.user.dto.request.JoinRequest;
+import upbrella.be.user.dto.request.LoginCodeRequest;
+import upbrella.be.user.dto.request.UpdateBankAccountRequest;
+import upbrella.be.user.dto.token.KakaoOauthInfo;
+import upbrella.be.user.entity.BlackList;
+import upbrella.be.user.entity.User;
+import upbrella.be.user.repository.BlackListRepository;
+import upbrella.be.user.service.OauthLoginService;
+import upbrella.be.user.service.UserService;
+import upbrella.be.util.AesEncryptor;
+
+import javax.persistence.EntityManager;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Transactional
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.ANY)
+public class UserIntegrationTest extends RestDocsSupport {
+
+    @Autowired
+    private OauthLoginService oauthLoginService;
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private KakaoOauthInfo kakaoOauthInfo;
+    @Autowired
+    private RentService rentService;
+    @Autowired
+    private AesEncryptor aesEncryptor;
+    @Autowired
+    private EntityManager em;
+    @Autowired
+    private BlackListRepository blackListRepository;
+    private MockHttpSession mockHttpSession = new MockHttpSession();
+    private User user;
+
+    @Override
+    protected Object initController() {
+        return new UserController(oauthLoginService, userService, kakaoOauthInfo, rentService);
+    }
+    @Nested
+    class contextJoined {
+
+        @BeforeEach
+        void setUp() {
+            Classification classification = FixtureBuilderFactory.builderClassification()
+                    .set("type", ClassificationType.CLASSIFICATION)
+                    .set("id", null).sample();
+
+            Classification subClassification = FixtureBuilderFactory.builderClassification()
+                    .set("type", ClassificationType.SUB_CLASSIFICATION)
+                    .set("id", null).sample();
+
+            em.persist(classification);
+            em.persist(subClassification);
+            em.flush();
+
+            user = FixtureBuilderFactory.builderUser(aesEncryptor)
+                    .set("id", null)
+                    .set("socialId", 1L)
+                    .sample();
+
+            em.persist(user);
+            em.flush();
+
+            StoreMeta storeMeta = FixtureBuilderFactory.builderStoreMeta()
+                    .set("id", null)
+                    .set("classification", classification)
+                    .set("subClassification", subClassification)
+                    .set("businessHours", null)
+                    .sample();
+
+            em.persist(storeMeta);
+            em.flush();
+
+            Umbrella umbrella = FixtureBuilderFactory.builderUmbrella()
+                    .set("id", null)
+                    .set("storeMeta", storeMeta)
+                    .sample();
+
+            em.persist(umbrella);
+            em.flush();
+
+            History history = FixtureBuilderFactory.builderHistory(aesEncryptor)
+                    .set("id", null)
+                    .set("umbrella", umbrella)
+                    .set("user", user)
+                    .set("returnedAt", null)
+                    .set("rentStoreMeta", storeMeta)
+                    .set("returnStoreMeta", null)
+                    .set("paidBy", user)
+                    .set("refundedBy", null)
+                    .sample();
+
+            em.persist(history);
+            em.flush();
+
+        }
+
+
+        @Test
+        @DisplayName("사용자는 카카오 소셜 로그인을 할 수 있다.")
+        void socialLoginTest() throws Exception {
+
+            // given
+            LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+
+            // when
+            mockMvc.perform(
+                            post("/users/oauth/login")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(code))
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            assertThat(mockHttpSession.getAttribute("kakaoUser")).isNotNull();
+        }
+
+
+        @Test
+        @DisplayName("사용자는 소셜 로그인 상태에서 업브렐라 로그인을 할 수 있다.")
+        void upbrellaLoginTest() throws Exception {
+
+            // given
+            LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+
+            // when & then
+            mockMvc.perform(
+                            post("/users/oauth/login")
+                                    .contentType(MediaType.APPLICATION_JSON)
+                                    .content(objectMapper.writeValueAsString(code))
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            mockMvc.perform(
+                            post("/users/login")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            assertThat(mockHttpSession.getAttribute("kakaoUser")).isNull();
+            assertThat(mockHttpSession.getAttribute("user")).isNotNull();
+        }
+
+        @DisplayName("사용자는 로그인된 유저 정보를 조회할 수 있다.")
+        @Test
+        void findUserInfoTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/loggedIn")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.id").exists())
+                    .andExpect(jsonPath("$.data.phoneNumber").exists())
+                    .andExpect(jsonPath("$.data.name").exists())
+                    .andExpect(jsonPath("$.data.bank").exists())
+                    .andExpect(jsonPath("$.data.accountNumber").exists());
+        }
+
+        @Test
+        @DisplayName("사용자는 유저가 빌린 우산을 조회할 수 있다.")
+        void findUmbrellaBorrowedByUserTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/loggedIn/umbrella")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data.uuid").exists())
+                    .andExpect(jsonPath("$.data.elapsedDay").exists());
+        }
+
+
+        @Test
+        @DisplayName("사용자는 로그아웃을 할 수 있다.")
+        void logoutTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", 1L).sample());
+
+            // when
+            mockMvc.perform(
+                            post("/users/logout")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk());
+
+            // then
+            assertThat(mockHttpSession.isInvalid()).isEqualTo(true);
+        }
+
+        @DisplayName("사용자는 회원 정보 목록을 조회할 수 있다.")
+        @Test
+        void findUsersInfoTest() throws Exception {
+
+            // when & then
+            mockMvc.perform(
+                            get("/admin/users")
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").exists())
+                    .andExpect(jsonPath("$.data.users.length()").value(1))
+                    .andExpect(jsonPath("$.data.users[0].id").exists())
+                    .andExpect(jsonPath("$.data.users[0].name").exists())
+                    .andExpect(jsonPath("$.data.users[0].phoneNumber").exists())
+                    .andExpect(jsonPath("$.data.users[0].bank").exists())
+                    .andExpect(jsonPath("$.data.users[0].accountNumber").exists())
+                    .andExpect(jsonPath("$.data.users[0].adminStatus").exists());
+        }
+
+        @Test
+        @DisplayName("로그인된 사용자는 우산 대여 정보를 조회할 수 있다.")
+        void readUserHistoriesTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when & then
+            mockMvc.perform(
+                            get("/users/histories")
+                                    .session(mockHttpSession)
+                    ).andDo(print())
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.data").exists())
+                    .andExpect(jsonPath("$.data.histories.length()").value(1))
+                    .andExpect(jsonPath("$.data.histories[0].umbrellaUuid").exists())
+                    .andExpect(jsonPath("$.data.histories[0].rentedAt").exists())
+                    .andExpect(jsonPath("$.data.histories[0].rentedStore").exists())
+                    .andExpect(jsonPath("$.data.histories[0].returned").value(false))
+                    .andExpect(jsonPath("$.data.histories[0].returned").exists());
+        }
+
+        @Test
+        @DisplayName("사용자는 은행 정보를 수정할 수 있다.")
+        void updateUserBankAccount() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+            UpdateBankAccountRequest updateBankAccountRequest = FixtureBuilderFactory.builderBankAccount().sample();
+
+            // when
+            mockMvc.perform(
+                    patch("/users/bankAccount")
+                            .session(mockHttpSession)
+                            .content(objectMapper.writeValueAsString(updateBankAccountRequest))
+                            .contentType(MediaType.APPLICATION_JSON)
+            ).andExpect(status().isOk());
+
+            // then
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(aesEncryptor.decrypt(foundUser.getBank())).isEqualTo(updateBankAccountRequest.getBank()),
+                    () -> assertThat(aesEncryptor.decrypt(foundUser.getAccountNumber())).isEqualTo(updateBankAccountRequest.getAccountNumber())
+            );
+        }
+
+        @Test
+        @DisplayName("사용자가 회원탈퇴를 하면, 삭제된 회원 정보로 변경되고 회원은 탈퇴된다.")
+        void deleteUserTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when
+            mockMvc.perform(
+                    delete("/users/loggedIn")
+                            .session(mockHttpSession)
+            ).andExpect(status().isOk());
+
+            // then
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(foundUser.getSocialId()).isEqualTo(0L),
+                    () -> assertThat(foundUser.getAccountNumber()).isEqualTo(null),
+                    () -> assertThat(foundUser.getBank()).isEqualTo(null),
+                    () -> assertThat(foundUser.getPhoneNumber()).isEqualTo("deleted"),
+                    () -> assertThat(foundUser.getName()).isEqualTo("탈퇴한 회원")
+            );
+
+
+        }
+
+        @Test
+        @DisplayName("관리자가 회원탈퇴 시키면, 블랙리스트에 추가되고 회원탈퇴가 된다.")
+        void withdrawUserTest() throws Exception {
+
+            // given
+            long userId = user.getId();
+
+            // when
+            mockMvc.perform(
+                            delete("/admin/users/{userId}", userId)
+                                    .session(mockHttpSession)
+                    ).andExpect(status().isOk())
+                    .andDo(print());
+
+            // then
+            assertThat(blackListRepository.findAll().size()).isEqualTo(1);
+            User foundUser = em.find(User.class, user.getId());
+            Assertions.assertAll(
+                    () -> assertThat(foundUser.getSocialId()).isEqualTo(0L),
+                    () -> assertThat(foundUser.getAccountNumber()).isEqualTo(null),
+                    () -> assertThat(foundUser.getBank()).isEqualTo(null),
+                    () -> assertThat(foundUser.getPhoneNumber()).isEqualTo("deleted"),
+                    () -> assertThat(foundUser.getName()).isEqualTo("정지된 회원")
+            );
+        }
+
+
+
+        @Test
+        @DisplayName("사용자는 자신의 계좌정보를 삭제할 수 있다.")
+        void deleteBackAccountTest() throws Exception {
+
+            // given
+            mockHttpSession.setAttribute("user", FixtureBuilderFactory.builderSessionUser().set("id", user.getId()).sample());
+
+            // when
+            mockMvc.perform(
+                            delete("/users/bankAccount")
+                                    .session(mockHttpSession)
+                    ).andExpect(status().isOk());
+
+            // then
+            assertThat(em.find(User.class, user.getId()).getBank()).isNull();
+        }
+
+    }
+
+
+
+    @Test
+    @DisplayName("사용자는 카카오 소셜 로그인 후 회원 가입을 할 수 있다.")
+    void joinTest() throws Exception {
+
+        // given
+        LoginCodeRequest code = LoginCodeRequest.builder().code("1kdfjq0243f").build();
+        mockMvc.perform(
+                        post("/users/oauth/login")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(code))
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk());
+        JoinRequest joinRequest = FixtureBuilderFactory.builderJoinRequest().sample();
+
+        // when
+        mockMvc.perform(
+                        post("/users/join")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(objectMapper.writeValueAsString(joinRequest))
+                                .session(mockHttpSession)
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(User.class, 1L)).isNotNull();
+    }
+
+    @Test
+    @DisplayName("사용자는 블랙리스트를 조회할 수 있다.")
+    void findAllBlackListTest() throws Exception {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        BlackList blackList = BlackList.builder()
+                .blockedAt(now)
+                .socialId(123L)
+                .build();
+
+        em.persist(blackList);
+        em.flush();
+
+        // then
+        mockMvc.perform(
+                        get("/users/blackList")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.blackList.length()").value(1))
+                .andExpect(jsonPath("$.data.blackList[0].id").value(blackList.getId()))
+                .andExpect(jsonPath("$.data.blackList[0].blockedAt").exists());
+    }
+
+    @Test
+    @DisplayName("사용자는 블랙리스트를 삭제할 수 있다.")
+    void deleteBlackListTest() throws Exception {
+
+        // given
+        LocalDateTime now = LocalDateTime.now();
+        BlackList blackList = BlackList.builder()
+                .blockedAt(now)
+                .socialId(123L)
+                .build();
+
+        em.persist(blackList);
+        em.flush();
+
+        // when
+        mockMvc.perform(
+                        delete("/users/blackList/{blackListId}", blackList.getId())
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(BlackList.class, blackList.getId())).isNull();
+    }
+
+
+    @Test
+    @DisplayName("관리자가 회원의 관리자 상태를 변경할 수 있다.")
+    void updateAdminStatusTest() throws Exception {
+
+        // given
+        User user = FixtureBuilderFactory.builderUser(aesEncryptor)
+                .set("id", null)
+                .set("socialId", 1L)
+                .set("adminStatus", false)
+                .sample();
+
+        em.persist(user);
+        em.flush();
+
+        // when
+        mockMvc.perform(
+                        patch("/admin/users/{userId}", user.getId())
+                ).andDo(print())
+                .andExpect(status().isOk());
+
+        // then
+        assertThat(em.find(User.class, user.getId()).isAdminStatus()).isTrue();
+    }
+}

--- a/src/test/java/upbrella/be/user/service/UserServiceTest.java
+++ b/src/test/java/upbrella/be/user/service/UserServiceTest.java
@@ -436,7 +436,6 @@ class UserServiceTest {
         // then
         assertAll(
                 () -> assertThat(userService.findBlackList().getBlackList().size()).isEqualTo(1),
-                () -> assertThat(userService.findBlackList().getBlackList().get(0).getSocialId()).isEqualTo(1L),
                 () -> assertThat(userService.findBlackList().getBlackList().get(0).getBlockedAt()).isEqualTo(now)
         );
     }

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    import: "classpath:application.properties"
+  datasource:
+    url: ${DATABASE_URL}
+    username: ${DATABASE_USERNAME}
+    password: ${DATABASE_PASSWORD}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+  jpa:
+    properties:
+      hibernate:
+        format_sql: true
+        show-sql: true
+  redis:
+    host: ${REDIS_HOST}
+    port: ${REDIS_PORT}
+    password: ${REDIS_PASSWORD}
+    timeout: 60000
+  session:
+    store-type: redis
+    timeout: 3600
+
+logging:
+  level:
+    org:
+      hibernate:
+        SQL: DEBUG
+        type:
+          descriptor:
+            sql: trace
+

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  profiles:
+    active: test


### PR DESCRIPTION
## What's Changed
* [fix] 유저 대여 내역 조회, 어드민 대여 내역 조회 시 정렬 로직을 ID 역순 정렬로 변경(#253) by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/276
* [fix] 탈퇴하거나 블랙리스트에 이미 등재된 회원 블랙 요청 시 예외 반환(#277) by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/278
* [test] 우산 통합 테스트 작성(#183) by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/279
* [fix, test] User 통합 테스트 작성 및 사용자 목록, 블랙리스트 목록에서 Social ID 필드 삭제 (#274, #188) by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/283
* [refactor] 우산 조회시 ect 추가 (#280) by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/285
* [fix] 상태 신고 기록 조회 (#284) by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/286
* [fix] 우산 Admin 현재 대여 번호, 협업 지점 이름, 협업 지점 ID 통일 (#282) by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/289


**Full Changelog**: https://github.com/UPbrella/UPbrella_back/compare/v0.3.3-dev...v0.3.4-dev