### PR TITLE
[refactor] 대여 기록 조회 api 성능 개선 (#300)

### DIFF
--- a/src/main/java/upbrella/be/rent/dto/HistoryInfoDto.java
+++ b/src/main/java/upbrella/be/rent/dto/HistoryInfoDto.java
@@ -1,0 +1,44 @@
+package upbrella.be.rent.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class HistoryInfoDto {
+
+    private long id;
+    private String name;
+    private String phoneNumber;
+    private String rentStoreName;
+    private LocalDateTime rentAt;
+    private long umbrellaUuid;
+    private String returnStoreName;
+    private LocalDateTime returnAt;
+    private LocalDateTime paidAt;
+    private String bank;
+    private String accountNumber;
+    private String etc;
+    private LocalDateTime refundedAt;
+
+    @QueryProjection
+    public HistoryInfoDto(long id, String name, String phoneNumber, String rentStoreName, LocalDateTime rentAt, long umbrellaUuid, String returnStoreName, LocalDateTime returnAt, LocalDateTime paidAt, String bank, String accountNumber, String etc, LocalDateTime refundedAt) {
+
+        this.id = id;
+        this.name = name;
+        this.phoneNumber = phoneNumber;
+        this.rentStoreName = rentStoreName;
+        this.rentAt = rentAt;
+        this.umbrellaUuid = umbrellaUuid;
+        this.returnStoreName = returnStoreName;
+        this.returnAt = returnAt;
+        this.paidAt = paidAt;
+        this.bank = bank;
+        this.accountNumber = accountNumber;
+        this.etc = etc;
+        this.refundedAt = refundedAt;
+    }
+}

--- a/src/main/java/upbrella/be/rent/dto/response/HistoryInfoDto.java
+++ b/src/main/java/upbrella/be/rent/dto/response/HistoryInfoDto.java
@@ -1,4 +1,4 @@
-package upbrella.be.rent.dto;
+package upbrella.be.rent.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Builder;

--- a/src/main/java/upbrella/be/rent/dto/response/RentalHistoryResponse.java
+++ b/src/main/java/upbrella/be/rent/dto/response/RentalHistoryResponse.java
@@ -2,7 +2,6 @@ package upbrella.be.rent.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
-import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.entity.History;
 
 import java.time.LocalDateTime;

--- a/src/main/java/upbrella/be/rent/dto/response/RentalHistoryResponse.java
+++ b/src/main/java/upbrella/be/rent/dto/response/RentalHistoryResponse.java
@@ -2,6 +2,7 @@ package upbrella.be.rent.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.*;
+import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.entity.History;
 
 import java.time.LocalDateTime;
@@ -28,47 +29,47 @@ public class RentalHistoryResponse {
     private String accountNumber;
     private String etc;
 
-    public static RentalHistoryResponse createReturnedHistory(History history, int elapsedDay, int totalRentalDay) {
-
-        return RentalHistoryResponse.builder()
-                .id(history.getId())
-                .name(history.getUser().getName())
-                .phoneNumber(history.getUser().getPhoneNumber())
-                .rentStoreName(history.getRentStoreMeta().getName())
-                .rentAt(history.getRentedAt())
-                .elapsedDay(elapsedDay)
-                .paid(history.getPaidAt() != null)
-                .umbrellaUuid(history.getUmbrella().getUuid())
-                .returnStoreName(history.getReturnStoreMeta().getName())
-                .returnAt(history.getReturnedAt())
-                .totalRentalDay(totalRentalDay)
-                .refundCompleted(isRefunded(history))
-                .bank(history.getBank())
-                .accountNumber(history.getAccountNumber())
-                .etc(history.getEtc())
-                .build();
-    }
-
-    public static RentalHistoryResponse createNonReturnedHistory(History history, int elapsedDay) {
-
-        return RentalHistoryResponse.builder()
-                .id(history.getId())
-                .name(history.getUser().getName())
-                .phoneNumber(history.getUser().getPhoneNumber())
-                .rentStoreName(history.getRentStoreMeta().getName())
-                .rentAt(history.getRentedAt())
-                .elapsedDay(elapsedDay)
-                .paid(history.getPaidAt() != null)
-                .umbrellaUuid(history.getUmbrella().getUuid())
-                .refundCompleted(isRefunded(history))
-                .bank(history.getBank())
-                .accountNumber(history.getAccountNumber())
-                .etc(history.getEtc())
-                .build();
-    }
-
     private static boolean isRefunded(History history) {
 
         return history.getRefundedAt() != null;
+    }
+
+    public static RentalHistoryResponse createReturnedHistory(HistoryInfoDto history, int elapsedDay, int totalRentalDay) {
+
+        return RentalHistoryResponse.builder()
+                .id(history.getId())
+                .name(history.getName())
+                .phoneNumber(history.getPhoneNumber())
+                .rentStoreName(history.getRentStoreName())
+                .rentAt(history.getRentAt())
+                .elapsedDay(elapsedDay)
+                .paid(history.getPaidAt() != null)
+                .umbrellaUuid(history.getUmbrellaUuid())
+                .returnStoreName(history.getReturnStoreName())
+                .returnAt(history.getReturnAt())
+                .totalRentalDay(totalRentalDay)
+                .refundCompleted(history.getRefundedAt() != null)
+                .bank(history.getBank())
+                .accountNumber(history.getAccountNumber())
+                .etc(history.getEtc())
+                .build();
+    }
+
+    public static RentalHistoryResponse createNonReturnedHistory(HistoryInfoDto history, int elapsedDay) {
+
+        return RentalHistoryResponse.builder()
+                .id(history.getId())
+                .name(history.getName())
+                .phoneNumber(history.getPhoneNumber())
+                .rentStoreName(history.getRentStoreName())
+                .rentAt(history.getRentAt())
+                .elapsedDay(elapsedDay)
+                .paid(history.getPaidAt() != null)
+                .umbrellaUuid(history.getUmbrellaUuid())
+                .refundCompleted(history.getRefundedAt() != null)
+                .bank(history.getBank())
+                .accountNumber(history.getAccountNumber())
+                .etc(history.getEtc())
+                .build();
     }
 }

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryCustom.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryCustom.java
@@ -1,7 +1,7 @@
 package upbrella.be.rent.repository;
 
 import org.springframework.data.domain.Pageable;
-import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.response.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.entity.History;
 

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryCustom.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryCustom.java
@@ -1,6 +1,7 @@
 package upbrella.be.rent.repository;
 
 import org.springframework.data.domain.Pageable;
+import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.entity.History;
 
@@ -9,6 +10,8 @@ import java.util.List;
 public interface RentRepositoryCustom {
 
     List<History> findAll(HistoryFilterRequest filter, Pageable pageable);
+
+    List<HistoryInfoDto> findHistoryInfos(HistoryFilterRequest filter, Pageable pageable);
 
     long countAll(HistoryFilterRequest filter, Pageable pageable);
 

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
@@ -4,7 +4,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
-import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.response.HistoryInfoDto;
 import upbrella.be.rent.dto.QTestDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.entity.History;

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
@@ -4,6 +4,8 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.QTestDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.entity.History;
 
@@ -71,5 +73,38 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
         }
 
         return history.refundedAt.isNull();
+    }
+
+    @Override
+    public List<HistoryInfoDto> findHistoryInfos(HistoryFilterRequest filter, Pageable pageable) {
+
+        List<HistoryInfoDto> fetch = queryFactory
+                .select(new QTestDto(
+                        history.id,
+                        history.user.name,
+                        history.user.phoneNumber,
+                        history.rentStoreMeta.name,
+                        history.rentedAt,
+                        history.umbrella.uuid,
+                        history.returnStoreMeta.name,
+                        history.returnedAt,
+                        history.paidAt,
+                        history.bank,
+                        history.accountNumber,
+                        history.etc,
+                        history.refundedAt
+                ))
+                .from(history)
+                .join(history.user, user)
+                .join(history.umbrella, umbrella)
+                .join(history.rentStoreMeta, storeMeta)
+                .leftJoin(history.returnStoreMeta, storeMeta)
+                .where(filterRefunded(filter))
+                .orderBy(history.id.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        return fetch;
     }
 }

--- a/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
+++ b/src/main/java/upbrella/be/rent/repository/RentRepositoryImpl.java
@@ -78,7 +78,7 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
     @Override
     public List<HistoryInfoDto> findHistoryInfos(HistoryFilterRequest filter, Pageable pageable) {
 
-        List<HistoryInfoDto> fetch = queryFactory
+        return queryFactory
                 .select(new QTestDto(
                         history.id,
                         history.user.name,
@@ -104,7 +104,5 @@ public class RentRepositoryImpl implements RentRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
-
-        return fetch;
     }
 }

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -4,7 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.response.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.request.ReturnUmbrellaByUserRequest;
@@ -75,7 +76,6 @@ public class RentService {
         String conditionReport = rentUmbrellaByUserRequest.getConditionReport();
 
 
-
         History history = rentRepository.save(History.ofCreatedByNewRent(willRentUmbrella, userToRent, rentalStore));
 
         ConditionReport conditionReportToSave = ConditionReport.builder()
@@ -138,8 +138,7 @@ public class RentService {
 
     private List<RentalHistoryResponse> findAllRentalHistory(HistoryFilterRequest filter, Pageable pageable) {
 
-        return findAll(filter, pageable)
-                .stream()
+        return findHistoryInfos(filter, pageable).stream()
                 .map(this::toRentalHistoryResponse)
                 .collect(Collectors.toList());
     }
@@ -167,15 +166,15 @@ public class RentService {
         return SingleHistoryResponse.ofUserHistory(history, returnAt, isReturned, isRefunded);
     }
 
-    private RentalHistoryResponse toRentalHistoryResponse(History history) {
+    private RentalHistoryResponse toRentalHistoryResponse(HistoryInfoDto history) {
 
-        int elapsedDay = LocalDateTime.now().getDayOfYear() - history.getRentedAt().getDayOfYear();
+        int elapsedDay = LocalDateTime.now().getDayOfYear() - history.getRentAt().getDayOfYear();
         int totalRentalDay = 0;
 
-        if (history.getReturnedAt() != null) {
+        if (history.getReturnAt() != null) {
 
-            elapsedDay = history.getReturnedAt().getDayOfYear() - history.getRentedAt().getDayOfYear();
-            totalRentalDay = history.getReturnedAt().getDayOfYear() - history.getRentedAt().getDayOfYear();
+            elapsedDay = history.getReturnAt().getDayOfYear() - history.getRentAt().getDayOfYear();
+            totalRentalDay = history.getReturnAt().getDayOfYear() - history.getRentAt().getDayOfYear();
 
             return RentalHistoryResponse.createReturnedHistory(history, elapsedDay, totalRentalDay);
         }
@@ -237,5 +236,10 @@ public class RentService {
         History history = findHistoryById(historyId);
 
         history.deleteBankAccount();
+    }
+
+    private List<HistoryInfoDto> findHistoryInfos(HistoryFilterRequest filter, Pageable pageable) {
+
+        return rentRepository.findHistoryInfos(filter, pageable);
     }
 }

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -2,6 +2,7 @@ package upbrella.be.config;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.dto.response.RentalHistoryResponse;
 import upbrella.be.rent.entity.History;
 import upbrella.be.store.entity.StoreMeta;
@@ -97,20 +98,20 @@ public class FixtureFactory {
         return fixtureMonkey.giveMeOne(KakaoLoginResponse.class);
     }
 
-    public static RentalHistoryResponse buildRentalHistoryResponseWithHistory(History history) {
+    public static RentalHistoryResponse buildRentalHistoryResponseWithHistory(HistoryInfoDto history) {
 
         return fixtureMonkey.giveMeBuilder(RentalHistoryResponse.class)
                 .set("id", history.getId())
-                .set("name", history.getUser().getName())
-                .set("phoneNumber", history.getUser().getPhoneNumber())
-                .set("rentStoreName", history.getRentStoreMeta().getName())
-                .set("rentAt", history.getRentedAt())
+                .set("name", history.getName())
+                .set("phoneNumber", history.getPhoneNumber())
+                .set("rentStoreName", history.getRentStoreName())
+                .set("rentAt", history.getRentAt())
                 .set("elapsedDay", calElapsedDay(history))
                 .set("paid", history.getPaidAt() != null)
-                .set("umbrellaUuid", history.getUmbrella().getUuid())
-                .set("returnStoreName", history.getReturnStoreMeta().getName())
-                .set("returnAt", history.getReturnedAt())
-                .set("totalRentalDay", history.getReturnedAt().getDayOfYear() - history.getRentedAt().getDayOfYear())
+                .set("umbrellaUuid", history.getUmbrellaUuid())
+                .set("returnStoreName", history.getReturnStoreName())
+                .set("returnAt", history.getReturnAt())
+                .set("totalRentalDay", history.getReturnAt().getDayOfYear() - history.getRentAt().getDayOfYear())
                 .set("refundCompleted", true)
                 .set("bank", history.getBank())
                 .set("accountNumber", history.getAccountNumber())
@@ -118,12 +119,12 @@ public class FixtureFactory {
                 .sample();
     }
 
-    private static int calElapsedDay(History history) {
+    private static int calElapsedDay(HistoryInfoDto history) {
 
-        int elapsedDay = LocalDateTime.now().getDayOfYear() - history.getRentedAt().getDayOfYear();
+        int elapsedDay = LocalDateTime.now().getDayOfYear() - history.getRentAt().getDayOfYear();
 
-        if (history.getReturnedAt() != null) {
-            elapsedDay = history.getReturnedAt().getDayOfYear() - history.getRentedAt().getDayOfYear();
+        if (history.getReturnAt() != null) {
+            elapsedDay = history.getReturnAt().getDayOfYear() - history.getRentAt().getDayOfYear();
         }
 
         return elapsedDay;

--- a/src/test/java/upbrella/be/config/FixtureFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureFactory.java
@@ -2,7 +2,7 @@ package upbrella.be.config;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
 import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
-import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.response.HistoryInfoDto;
 import upbrella.be.rent.dto.response.RentalHistoryResponse;
 import upbrella.be.rent.entity.History;
 import upbrella.be.store.entity.StoreMeta;

--- a/src/test/java/upbrella/be/rent/service/RentServiceTest.java
+++ b/src/test/java/upbrella/be/rent/service/RentServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.config.FixtureFactory;
+import upbrella.be.rent.dto.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
@@ -120,7 +121,7 @@ class RentServiceTest {
                 .id(1L)
                 .content("상태 양호")
                 .history(history)
-                .build() ;
+                .build();
 
     }
 
@@ -200,7 +201,7 @@ class RentServiceTest {
     class findAllHistories {
 
         private List<RentalHistoryResponse> expectedRentalHistoryResponses = new ArrayList<>();
-        private List<History> generatedHistories = new ArrayList<>();
+        private List<HistoryInfoDto> generatedHistories = new ArrayList<>();
 
         @Test
         @DisplayName("조건이 없는 경우 전체 대여/반납 현황을 조회할 수 있다.")
@@ -213,8 +214,21 @@ class RentServiceTest {
             Pageable pageable = PageRequest.of(0, 5);
 
             for (int i = 0; i < 5; i++) {
-                generatedHistories.add(FixtureBuilderFactory.builderHistory(aesEncryptor)
-                        .sample());
+                generatedHistories.add(HistoryInfoDto.builder()
+                        .id(i)
+                        .name("테스터")
+                        .phoneNumber("010-1234-5678")
+                        .rentStoreName("motive study cafe")
+                        .rentAt(LocalDateTime.of(1000, 12, 3, 4, 24))
+                        .umbrellaUuid(99L)
+                        .returnStoreName("motive study cafe")
+                        .returnAt(LocalDateTime.of(1000, 12, 3, 4, 25))
+                        .paidAt(LocalDateTime.of(1000, 12, 3, 4, 26))
+                        .bank("국민은행")
+                        .accountNumber("1234567890")
+                        .etc("etc")
+                        .refundedAt(LocalDateTime.of(1000, 12, 3, 4, 27))
+                        .build());
             }
 
             expectedRentalHistoryResponses = generatedHistories.stream()
@@ -229,7 +243,7 @@ class RentServiceTest {
                     .countOfAllPages(1L)
                     .build();
 
-            given(rentRepository.findAll(filter, pageable))
+            given(rentRepository.findHistoryInfos(filter, pageable))
                     .willReturn(generatedHistories);
             given(rentRepository.countAll(filter, pageable))
                     .willReturn(5L);
@@ -246,7 +260,7 @@ class RentServiceTest {
                     () -> then(rentRepository).should(times(1))
                             .countAll(filter, pageable),
                     () -> then(rentRepository).should(times(1))
-                            .findAll(filter, pageable)
+                            .findHistoryInfos(filter, pageable)
             );
         }
     }

--- a/src/test/java/upbrella/be/rent/service/RentServiceTest.java
+++ b/src/test/java/upbrella/be/rent/service/RentServiceTest.java
@@ -12,7 +12,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import upbrella.be.config.FixtureBuilderFactory;
 import upbrella.be.config.FixtureFactory;
-import upbrella.be.rent.dto.HistoryInfoDto;
+import upbrella.be.rent.dto.response.HistoryInfoDto;
 import upbrella.be.rent.dto.request.HistoryFilterRequest;
 import upbrella.be.rent.dto.request.RentUmbrellaByUserRequest;
 import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;


### PR DESCRIPTION
## 🟢 구현내용
- #300 

## 🧩 고민과 해결과정
- History 조회시 반환되는 필드에 비해 너무 많은 필드가 조회되는 현상을 발견했습니다. 
이를 해결하기 위해 Entity를 조회하는 것이 아닌 필요한 필드만을 조회하도록 변경하였습니다. 

개선 전 쿼리 
```SQL
select
        history0_.id as id1_4_0_,
        user1_.id as id1_10_1_,
        user2_.id as id1_10_2_,
        umbrella3_.id as id1_9_3_,
        storemeta4_.id as id1_8_4_,
        storemeta5_.id as id1_8_5_,
        history0_.account_number as account_2_4_0_,
        history0_.bank as bank3_4_0_,
        history0_.etc as etc4_4_0_,
        history0_.paid_at as paid_at5_4_0_,
        history0_.paid_by as paid_by9_4_0_,
        history0_.refunded_at as refunded6_4_0_,
        history0_.refunded_by as refunde10_4_0_,
        history0_.rent_store_meta_id as rent_st11_4_0_,
        history0_.rented_at as rented_a7_4_0_,
        history0_.return_store_meta_id as return_12_4_0_,
        history0_.returned_at as returned8_4_0_,
        history0_.umbrella_id as umbrell13_4_0_,
        history0_.user_id as user_id14_4_0_,
        user1_.account_number as account_2_10_1_,
        user1_.admin_status as admin_st3_10_1_,
        user1_.bank as bank4_10_1_,
        user1_.email as email5_10_1_,
        user1_.name as name6_10_1_,
        user1_.phone_number as phone_nu7_10_1_,
        user1_.social_id as social_i8_10_1_,
        user2_.account_number as account_2_10_2_,
        user2_.admin_status as admin_st3_10_2_,
        user2_.bank as bank4_10_2_,
        user2_.email as email5_10_2_,
        user2_.name as name6_10_2_,
        user2_.phone_number as phone_nu7_10_2_,
        user2_.social_id as social_i8_10_2_,
        umbrella3_.created_at as created_2_9_3_,
        umbrella3_.deleted as deleted3_9_3_,
        umbrella3_.etc as etc4_9_3_,
        umbrella3_.missed as missed5_9_3_,
        umbrella3_.rentable as rentable6_9_3_,
        umbrella3_.store_meta_id as store_me8_9_3_,
        umbrella3_.uuid as uuid7_9_3_,
        storemeta4_.activated as activate2_8_4_,
        storemeta4_.category as category3_8_4_,
        storemeta4_.classification_id as classifi9_8_4_,
        storemeta4_.deleted as deleted4_8_4_,
        storemeta4_.latitude as latitude5_8_4_,
        storemeta4_.longitude as longitud6_8_4_,
        storemeta4_.name as name7_8_4_,
        storemeta4_.password as password8_8_4_,
        storemeta4_.sub_classification_id as sub_cla10_8_4_,
        storemeta5_.activated as activate2_8_5_,
        storemeta5_.category as category3_8_5_,
        storemeta5_.classification_id as classifi9_8_5_,
        storemeta5_.deleted as deleted4_8_5_,
        storemeta5_.latitude as latitude5_8_5_,
        storemeta5_.longitude as longitud6_8_5_,
        storemeta5_.name as name7_8_5_,
        storemeta5_.password as password8_8_5_,
        storemeta5_.sub_classification_id as sub_cla10_8_5_ 
    from
        history history0_ 
    inner join
        user user1_ 
            on history0_.user_id=user1_.id 
    left outer join
        user user2_ 
            on history0_.refunded_by=user2_.id 
    inner join
        umbrella umbrella3_ 
            on history0_.umbrella_id=umbrella3_.id 
    inner join
        store_meta storemeta4_ 
            on history0_.rent_store_meta_id=storemeta4_.id 
    left outer join
        store_meta storemeta5_ 
            on history0_.return_store_meta_id=storemeta5_.id 
    order by
        history0_.id desc
```

개선 후 쿼리 
```SQL
select
        history0_.id as col_0_0_,
        user1_.name as col_1_0_,
        user1_.phone_number as col_2_0_,
        storemeta4_.name as col_3_0_,
        history0_.rented_at as col_4_0_,
        umbrella2_.uuid as col_5_0_,
        storemeta4_.name as col_6_0_,
        history0_.refunded_at as col_7_0_,
        history0_.paid_at as col_8_0_,
        history0_.bank as col_9_0_,
        history0_.account_number as col_10_0_,
        history0_.etc as col_11_0_ 
    from
        history history0_ 
    inner join
        user user1_ 
            on history0_.user_id=user1_.id 
    inner join
        umbrella umbrella2_ 
            on history0_.umbrella_id=umbrella2_.id 
    inner join
        store_meta storemeta3_ 
            on history0_.rent_store_meta_id=storemeta3_.id 
    left outer join
        store_meta storemeta4_ 
            on history0_.return_store_meta_id=storemeta4_.id 
    order by
        history0_.id desc limit ?   
```

데이터 백만건 기준 
쿼리 실행 속도 : 0.032 -> 0.012 (62.5% 개선) 
쿼리 비용 : 6284054.81 -> 5198930.47 (17.29% 개선) 