### PR TITLE
[feat] nGrinder 테스트 자동화 (#304)

### DIFF
--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -27,79 +27,79 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-      - name: Set application properties
-        run: |
-          touch src/main/resources/application.properties
-          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
-          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
+#      - name: Set application properties
+#        run: |
+#          touch src/main/resources/application.properties
+#          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
+#          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
+#
+#      - name: Build with Gradle
+#        run: |
+#          chmod +x gradlew
+#          ./gradlew clean build
+#        env:
+#          WORKING_DIRECTORY: ${{ env.WORKING_DIRECTORY }}
 
-      - name: Build with Gradle
-        run: |
-          chmod +x gradlew
-          ./gradlew clean build
-        env:
-          WORKING_DIRECTORY: ${{ env.WORKING_DIRECTORY }}
-
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
-
-
-      - name: Make zip file
-        run: zip -r ./$GITHUB_SHA.zip .
-        shell: bash
-
-
-      - name: Upload to S3
-        run:
-          aws s3 cp $GITHUB_SHA.zip s3://${{ env.S3_BUCKET_NAME }}/server-dev-deploy/$GITHUB_SHA.zip --region ${{ secrets.AWS_REGION }}
-
-      - name: Code Deploy
-        run: |
-          aws deploy create-deployment \
-          --deployment-config-name CodeDeployDefault.AllAtOnce \
-          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
-          --s3-location bucket=${{ env.S3_BUCKET_NAME }},bundleType=zip,key=server-dev-deploy/$GITHUB_SHA.zip
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v1
+#        with:
+#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          aws-region: ${{ secrets.AWS_REGION }}
+#
+#
+#      - name: Make zip file
+#        run: zip -r ./$GITHUB_SHA.zip .
+#        shell: bash
+#
+#
+#      - name: Upload to S3
+#        run:
+#          aws s3 cp $GITHUB_SHA.zip s3://${{ env.S3_BUCKET_NAME }}/server-dev-deploy/$GITHUB_SHA.zip --region ${{ secrets.AWS_REGION }}
+#
+#      - name: Code Deploy
+#        run: |
+#          aws deploy create-deployment \
+#          --deployment-config-name CodeDeployDefault.AllAtOnce \
+#          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
+#          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
+#          --s3-location bucket=${{ env.S3_BUCKET_NAME }},bundleType=zip,key=server-dev-deploy/$GITHUB_SHA.zip
 
       # test에 필요한 ec2 인스턴스를 aws cli를 통해 실행
-      - name: Start nGrinder EC2 - (Controller, Agent)
-        run: aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-
-      # Dev server 완전히 실행될 때까지 기다림
-      - name: Sleep for 30 seconds - waiting controller,agent run
-        run: sleep 30s
-        shell: bash
-
-      # EC2- Ngrinder Controller를 실행
-      - name: Ngrinder Controller Start
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.AWS_EC2_CONTROLLER_IP }}
-          username: ubuntu
-          key: ${{ secrets.AWS_SECRET_PEM }}
-          script: |
-            bash ./controller.sh
-
-      - name: Ngrinder Agent Start
-        uses: appleboy/ssh-action@master
-        with:
-          host: ${{ secrets.AWS_EC2_AGENT_IP }}
-          username: ubuntu
-          key: ${{ secrets.AWS_SECRET_PEM }}
-          script: |
-            bash ./agent.sh
-
-      - name: waiting controller,agent run
-        run: sleep 30s
-        shell: bash
+#      - name: Start nGrinder EC2 - (Controller, Agent)
+#        run: aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
+#        env:
+#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+#
+#      # Dev server 완전히 실행될 때까지 기다림
+#      - name: Sleep for 30 seconds - waiting controller,agent run
+#        run: sleep 30s
+#        shell: bash
+#
+#      # EC2- Ngrinder Controller를 실행
+#      - name: Ngrinder Controller Start
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.AWS_EC2_CONTROLLER_IP }}
+#          username: ubuntu
+#          key: ${{ secrets.AWS_SECRET_PEM }}
+#          script: |
+#            bash ./controller.sh
+#
+#      - name: Ngrinder Agent Start
+#        uses: appleboy/ssh-action@master
+#        with:
+#          host: ${{ secrets.AWS_EC2_AGENT_IP }}
+#          username: ubuntu
+#          key: ${{ secrets.AWS_SECRET_PEM }}
+#          script: |
+#            bash ./agent.sh
+#
+#      - name: waiting controller,agent run
+#        run: sleep 30s
+#        shell: bash
 
       - name: nGrinder Test
         uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -143,4 +143,4 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -109,7 +109,7 @@ jobs:
           username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
           password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 0:4:0, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
           timeout: '60000'
 
       - name: waiting test for 300 seconds

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -109,7 +109,7 @@ jobs:
           username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
           password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 30, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
           timeout: '60000'
 
       - name: waiting test for 300 seconds

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -109,7 +109,7 @@ jobs:
           username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
           password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 15, "processes" : 2, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 15, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 240000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 30, "processes" : 2, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 15, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
           timeout: '60000'
 
       - name: waiting test for 300 seconds

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -2,7 +2,7 @@ name: Upbrella DEV CI
 
 on:
   push:
-    branches: [ "release-dev" ]
+    branches: [ "feat/#304-nGrinder-test" ]
 
 env:
   WORKING_DIRECTORY: ./
@@ -64,3 +64,83 @@ jobs:
           --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
           --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
           --s3-location bucket=${{ env.S3_BUCKET_NAME }},bundleType=zip,key=server-dev-deploy/$GITHUB_SHA.zip
+
+      # test에 필요한 ec2 인스턴스를 aws cli를 통해 실행
+      - name: Start nGrinder EC2 - (Controller, Agent)
+        run: aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      # Dev server 완전히 실행될 때까지 기다림
+      - name: Sleep for 30 seconds - waiting controller,agent run
+        run: sleep 30s
+        shell: bash
+
+      # EC2- Ngrinder Controller를 실행
+      - name: Ngrinder Controller Start
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_EC2_CONTROLLER_IP }}
+          username: ubuntu
+          key: ${{ secrets.AWS_SECRET_PEM }}
+          script: |
+            bash ./controller.sh
+
+      - name: Ngrinder Agent Start
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_EC2_AGENT_IP }}
+          username: ubuntu
+          key: ${{ secrets.AWS_SECRET_PEM }}
+          script: |
+            bash ./agent.sh
+
+      - name: waiting controller,agent run
+        run: sleep 30s
+        shell: bash
+
+      - name: nGrinder Test
+        uses: fjogeleit/http-request-action@v1
+        with:
+          url: 'http://${{ secrets.AWS_EC2_CONTROLLER_IP }}/perftest/api'
+          method: 'POST'
+          username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
+          password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
+          customHeaders: '{"Content-Type": "application/json"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 0:4:0, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          timeout: '60000'
+
+      - name: waiting test for 300 seconds
+        run: sleep 300s
+        shell: bash
+
+
+      # Ngrinder Rest Api 를 통해 테스트 결과 조회
+      - name: Get Ngrinder test result ...
+        uses: satak/webrequest-action@master
+        id: NgrinderTestResult
+        with:
+          url: 'http://${{ secrets.AWS_EC2_CONTROLLER_IP }}/perftest/api?page=0'
+          method: GET
+          username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
+          password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
+
+
+      - name: send test result to slack
+        uses: 8398a7/action-slack@v3
+        with:
+          text: '${{ steps.NgrinderTestResult.outputs.output }}'
+          status: ${{ job.status }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always() # Pick up events even if the job fails or is canceled.
+
+
+      - name: Stop Ngrinder EC2 - (Controller, Agent, Test Server)
+        run: aws ec2 terminate-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -2,7 +2,7 @@ name: Upbrella DEV CI
 
 on:
   push:
-    branches: [ "feat/#304-nGrinder-test" ]
+    branches: [ "release-dev" ]
 
 env:
   WORKING_DIRECTORY: ./
@@ -27,79 +27,79 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
 
-#      - name: Set application properties
-#        run: |
-#          touch src/main/resources/application.properties
-#          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
-#          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
-#
-#      - name: Build with Gradle
-#        run: |
-#          chmod +x gradlew
-#          ./gradlew clean build
-#        env:
-#          WORKING_DIRECTORY: ${{ env.WORKING_DIRECTORY }}
+      - name: Set application properties
+        run: |
+          touch src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_DEV }}" > src/main/resources/application.properties
+          echo "${{ secrets.APPLICATION_PROPERTIES_TEST }}" > src/test/resources/application.properties
 
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v1
-#        with:
-#          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          aws-region: ${{ secrets.AWS_REGION }}
-#
-#
-#      - name: Make zip file
-#        run: zip -r ./$GITHUB_SHA.zip .
-#        shell: bash
-#
-#
-#      - name: Upload to S3
-#        run:
-#          aws s3 cp $GITHUB_SHA.zip s3://${{ env.S3_BUCKET_NAME }}/server-dev-deploy/$GITHUB_SHA.zip --region ${{ secrets.AWS_REGION }}
-#
-#      - name: Code Deploy
-#        run: |
-#          aws deploy create-deployment \
-#          --deployment-config-name CodeDeployDefault.AllAtOnce \
-#          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
-#          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
-#          --s3-location bucket=${{ env.S3_BUCKET_NAME }},bundleType=zip,key=server-dev-deploy/$GITHUB_SHA.zip
+      - name: Build with Gradle
+        run: |
+          chmod +x gradlew
+          ./gradlew clean build
+        env:
+          WORKING_DIRECTORY: ${{ env.WORKING_DIRECTORY }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+
+      - name: Make zip file
+        run: zip -r ./$GITHUB_SHA.zip .
+        shell: bash
+
+
+      - name: Upload to S3
+        run:
+          aws s3 cp $GITHUB_SHA.zip s3://${{ env.S3_BUCKET_NAME }}/server-dev-deploy/$GITHUB_SHA.zip --region ${{ secrets.AWS_REGION }}
+
+      - name: Code Deploy
+        run: |
+          aws deploy create-deployment \
+          --deployment-config-name CodeDeployDefault.AllAtOnce \
+          --application-name ${{ env.CODE_DEPLOY_APPLICATION_NAME }} \
+          --deployment-group-name ${{ env.CODE_DEPLOY_DEPLOYMENT_GROUP_NAME }} \
+          --s3-location bucket=${{ env.S3_BUCKET_NAME }},bundleType=zip,key=server-dev-deploy/$GITHUB_SHA.zip
 
       # test에 필요한 ec2 인스턴스를 aws cli를 통해 실행
-#      - name: Start nGrinder EC2 - (Controller, Agent)
-#        run: aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
-#        env:
-#          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-#          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-#          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-#
-#      # Dev server 완전히 실행될 때까지 기다림
-#      - name: Sleep for 30 seconds - waiting controller,agent run
-#        run: sleep 30s
-#        shell: bash
-#
-#      # EC2- Ngrinder Controller를 실행
-#      - name: Ngrinder Controller Start
-#        uses: appleboy/ssh-action@master
-#        with:
-#          host: ${{ secrets.AWS_EC2_CONTROLLER_IP }}
-#          username: ubuntu
-#          key: ${{ secrets.AWS_SECRET_PEM }}
-#          script: |
-#            bash ./controller.sh
-#
-#      - name: Ngrinder Agent Start
-#        uses: appleboy/ssh-action@master
-#        with:
-#          host: ${{ secrets.AWS_EC2_AGENT_IP }}
-#          username: ubuntu
-#          key: ${{ secrets.AWS_SECRET_PEM }}
-#          script: |
-#            bash ./agent.sh
-#
-#      - name: waiting controller,agent run
-#        run: sleep 30s
-#        shell: bash
+      - name: Start nGrinder EC2 - (Controller, Agent)
+        run: aws ec2 start-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+
+      # Dev server 완전히 실행될 때까지 기다림
+      - name: Sleep for 30 seconds - waiting controller,agent run
+        run: sleep 30s
+        shell: bash
+
+      # EC2- Ngrinder Controller를 실행
+      - name: Ngrinder Controller Start
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_EC2_CONTROLLER_IP }}
+          username: ubuntu
+          key: ${{ secrets.AWS_SECRET_PEM }}
+          script: |
+            bash ./controller.sh
+
+      - name: Ngrinder Agent Start
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{ secrets.AWS_EC2_AGENT_IP }}
+          username: ubuntu
+          key: ${{ secrets.AWS_SECRET_PEM }}
+          script: |
+            bash ./agent.sh
+
+      - name: waiting controller,agent run
+        run: sleep 30s
+        shell: bash
 
       - name: nGrinder Test
         uses: fjogeleit/http-request-action@v1

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -109,7 +109,7 @@ jobs:
           username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
           password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 15, "processes" : 2, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 15, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
           timeout: '60000'
 
       - name: waiting test for 300 seconds

--- a/.github/workflows/release-dev-ci.yml
+++ b/.github/workflows/release-dev-ci.yml
@@ -109,7 +109,7 @@ jobs:
           username: ${{ secrets.NGRINDER_ADMIN_USERNAME }}
           password: ${{ secrets.NGRINDER_ADMIN_PASSWORD }}
           customHeaders: '{"Content-Type": "application/json"}'
-          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 1, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
+          data: '{"param" : "${{ secrets.AWS_EC2_TEST_SERVER_IP }}", "testName" : "upbrella-test", "tagString" : "upbrella-test", "description" : "upbrella-test", "scheduledTime" : "", "useRampUp": false, "rampUpType" : "PROCESS", "threshold" : "D", "scriptName" : "upbrella-test.groovy", "duration" : 120000, "runCount" : 1, "agentCount" : 1, "vuserPerAgent" : 30, "processes" : 1, "rampUpInitCount" : 0, "rampUpInitSleepTime" : 0, "rampUpStep" : 1, "rampUpIncrementInterval" : 1000, "threads": 1, "testComment" : "upbrella-test", "samplingInterval" : 2, "ignoreSampleCount" : 0, "status" : "READY"}'
           timeout: '60000'
 
       - name: waiting test for 300 seconds
@@ -139,7 +139,7 @@ jobs:
 
 
       - name: Stop Ngrinder EC2 - (Controller, Agent, Test Server)
-        run: aws ec2 terminate-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
+        run: aws ec2 stop-instances --instance-ids ${{ secrets.AWS_EC2_NGRINDER_CONTROLLER }} ${{ secrets.AWS_EC2_NGRINDER_AGENT }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/src/main/java/upbrella/be/config/AuthConfig.java
+++ b/src/main/java/upbrella/be/config/AuthConfig.java
@@ -32,7 +32,8 @@ public class AuthConfig implements WebMvcConfigurer {
                         "/index.html",
                         "/error/**",
                         "/api/error/**",
-                        "/docs/**");
+                        "/docs/**",
+                        "/nGrinder/**");
 
 
         registry.addInterceptor(adminInterceptor)

--- a/src/main/java/upbrella/be/util/NGrinderController.java
+++ b/src/main/java/upbrella/be/util/NGrinderController.java
@@ -1,0 +1,58 @@
+package upbrella.be.util;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import upbrella.be.rent.dto.request.HistoryFilterRequest;
+import upbrella.be.rent.dto.response.RentalHistoriesPageResponse;
+import upbrella.be.rent.service.RentService;
+import upbrella.be.store.dto.response.AllStoreResponse;
+import upbrella.be.store.dto.response.SingleStoreResponse;
+import upbrella.be.store.service.StoreDetailService;
+
+import java.util.List;
+
+@Profile("dev")
+@Controller
+@RequiredArgsConstructor
+public class NGrinderController {
+
+    private final RentService rentService;
+    private final StoreDetailService storeDetailService;
+
+    @GetMapping("/nGrinder/storeTest")
+    public ResponseEntity<CustomResponse<AllStoreResponse>> findAllStores() {
+
+        List<SingleStoreResponse> allStores = storeDetailService.findAllStores();
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "어드민 가게 전체 조회 성공",
+                        AllStoreResponse.builder()
+                                .stores(allStores)
+                                .build()
+                ));
+    }
+
+    @GetMapping("/nGrinder/historyTest")
+    public ResponseEntity<CustomResponse<RentalHistoriesPageResponse>> findRentalHistory(@ModelAttribute HistoryFilterRequest filter, Pageable pageable) {
+
+        RentalHistoriesPageResponse histories = rentService.findAllHistories(filter, pageable);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "어드민 대여 내역 조회 성공",
+                        histories
+                ));
+    }
+}


### PR DESCRIPTION
## 🟢 구현내용
- #304 

## 🧩 고민과 해결과정
- nGrinder 테스트를 배포시마다 자동화를 위해 cli를 통한 ec2 실행, nGrinder Test, ec2 중지 기능을 완성했습니다. 
- 로그인 기능으로 인해 nGrinder용 컨트롤러를 추가했습니다. 이는 nGrinder 스크립트 공부 후 실제 플로우대로 진행되도록 수정할 예정입니다. 
- nGrinder Controller는 dev 에서만 동작하도록 @Profile 설정을 해두었습니다. 