### PR TITLE
[refactor] 협업지점 조회 api 성능 개선 (#272)

### DIFF
--- a/src/main/java/upbrella/be/config/JacksonConfig.java
+++ b/src/main/java/upbrella/be/config/JacksonConfig.java
@@ -1,0 +1,18 @@
+package upbrella.be.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    public ObjectMapper objectMapper(Jackson2ObjectMapperBuilder builder) {
+
+        ObjectMapper objectMapper = builder.build();
+        objectMapper.registerModule(new JavaTimeModule()); // Java 8의 java.time을 지원하는 모듈 등록
+        return objectMapper;
+    }
+}

--- a/src/main/java/upbrella/be/config/RedisCacheConfig.java
+++ b/src/main/java/upbrella/be/config/RedisCacheConfig.java
@@ -1,0 +1,30 @@
+package upbrella.be.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager testCacheManager(RedisConnectionFactory cf) {
+
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofMinutes(3L));
+
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(cf).cacheDefaults(redisCacheConfiguration).build();
+    }
+}

--- a/src/main/java/upbrella/be/store/dto/response/SingleBusinessHourResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleBusinessHourResponse.java
@@ -1,9 +1,14 @@
 package upbrella.be.store.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalTimeSerializer;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import upbrella.be.store.entity.BusinessHour;
 
 import java.time.DayOfWeek;
@@ -11,12 +16,17 @@ import java.time.LocalTime;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class SingleBusinessHourResponse {
 
     private DayOfWeek date;
+    @JsonSerialize(using = LocalTimeSerializer.class)
+    @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JsonFormat(pattern = "HH:mm")
     private LocalTime openAt;
+    @JsonSerialize(using = LocalTimeSerializer.class)
+    @JsonDeserialize(using = LocalTimeDeserializer.class)
     @JsonFormat(pattern = "HH:mm")
     private LocalTime closeAt;
 

--- a/src/main/java/upbrella/be/store/dto/response/SingleImageUrlResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleImageUrlResponse.java
@@ -3,10 +3,12 @@ package upbrella.be.store.dto.response;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import upbrella.be.store.entity.StoreImage;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
 public class SingleImageUrlResponse {
 

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -3,13 +3,14 @@ package upbrella.be.store.dto.response;
 import lombok.*;
 import upbrella.be.store.entity.StoreDetail;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-public class SingleStoreResponse {
+public class SingleStoreResponse implements Serializable {
 
     private long id;
     private String name;

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -1,6 +1,8 @@
 package upbrella.be.store.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.store.dto.request.UpdateStoreRequest;
@@ -27,6 +29,7 @@ public class StoreDetailService {
     private final StoreImageService storeImageService;
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void updateStore(Long storeId, UpdateStoreRequest request) {
 
         StoreDetail storeDetailById = findStoreDetailByStoreMetaId(storeId);
@@ -63,6 +66,7 @@ public class StoreDetailService {
     }
 
     @Transactional
+    @Cacheable(value = "stores", key = "'allStores'")
     public List<SingleStoreResponse> findAllStores() {
 
         List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
@@ -71,7 +75,7 @@ public class StoreDetailService {
                 .collect(Collectors.toList());
     }
 
-    public SingleStoreResponse createSingleStoreResponse(StoreDetail storeDetail) {
+    private SingleStoreResponse createSingleStoreResponse(StoreDetail storeDetail) {
 
         List<SingleImageUrlResponse> sortedImageUrls = storeDetail.getSortedStoreImages().stream()
                 .map(SingleImageUrlResponse::createImageUrlResponse)
@@ -84,6 +88,7 @@ public class StoreDetailService {
         return SingleStoreResponse.ofCreateSingleStoreResponse(storeDetail, thumbnail, sortedImageUrls, businessHours);
     }
 
+    @Transactional
     public AllStoreIntroductionResponse findAllStoreIntroductions() {
 
         List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
@@ -100,6 +105,7 @@ public class StoreDetailService {
         return AllStoreIntroductionResponse.of(storeDetailsByClassification);
     }
 
+    @Transactional
     public void saveStoreDetail(StoreDetail storeDetail) {
 
         storeDetailRepository.save(storeDetail);

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -2,6 +2,7 @@ package upbrella.be.store.service;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -32,6 +33,7 @@ public class StoreImageService {
     private String bucketName;
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public String uploadFile(MultipartFile file, long storeDetailId, String randomId) {
 
         String fileName = file.getOriginalFilename() + randomId;
@@ -58,6 +60,7 @@ public class StoreImageService {
     }
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void deleteFile(long imageId) {
 
         StoreImage storeImage = storeImageRepository.findById(imageId)

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -36,6 +36,7 @@ public class StoreImageService {
     @CacheEvict(value = "stores", key = "'allStores'")
     public String uploadFile(MultipartFile file, long storeDetailId, String randomId) {
 
+        StringBuilder sb = new StringBuilder();
         String fileName = file.getOriginalFilename() + randomId;
         String contentType = file.getContentType();
 
@@ -48,7 +49,12 @@ public class StoreImageService {
                 .contentType(contentType)
                 .build();
 
-        String url = "https://" + bucketName + ".s3.ap-northeast-2.amazonaws.com/store-image/" + fileName;
+        sb.append("https://")
+                .append(bucketName)
+                .append(".s3.ap-northeast-2.amazonaws.com/store-image/")
+                .append(fileName);
+
+        String url = sb.toString();
 
         try {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -49,12 +49,11 @@ public class StoreImageService {
                 .contentType(contentType)
                 .build();
 
-        sb.append("https://")
+        String url = sb.append("https://")
                 .append(bucketName)
                 .append(".s3.ap-northeast-2.amazonaws.com/store-image/")
-                .append(fileName);
-
-        String url = sb.toString();
+                .append(fileName)
+                .toString();
 
         try {
             s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.service;
 
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -84,6 +85,7 @@ public class StoreMetaService {
     }
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void createStore(CreateStoreRequest store) {
 
         StoreMeta storeMeta = saveStoreMeta(store);
@@ -91,6 +93,7 @@ public class StoreMetaService {
     }
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void deleteStoreMeta(long storeMetaId) {
 
         findStoreMetaById(storeMetaId).delete();
@@ -137,6 +140,7 @@ public class StoreMetaService {
     }
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void activateStoreStatus(long storeId) {
 
         StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
@@ -150,6 +154,7 @@ public class StoreMetaService {
     }
 
     @Transactional
+    @CacheEvict(value = "stores", key = "'allStores'")
     public void inactivateStoreStatus(long storeId) {
 
         StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -10,7 +10,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
-        show-sql: true
+        show-sql: false
   redis:
     host: ${REDIS_HOST}
     port: ${REDIS_PORT}
@@ -20,12 +20,4 @@ spring:
     store-type: redis
     timeout: 3600
 
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql: trace
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,13 +19,3 @@ spring:
   session:
     store-type: redis
     timeout: 3600
-
-    show-sql: true
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql: trace


### PR DESCRIPTION
## 🟢 구현내용
- #272 

## 🧩 고민과 해결과정
- Redis를 로그인에만 사용하는 것이 아닌, DB 성능 최적화를 위해 어떻게 할 수 있을까 고민하면서 새롭게 적용하였습니다. 
- 로그인과 함께 사용하는 중이라 redis 서버에 부하가 갈 수 있으니, 스케일업과 주기적인 모니터링을 통해 문제를 해결할 예정입니다. 
- API 성능의 경우 평균 117 TPS -> 2386 TPS로 1943.59%의 성능 향상을 이루어냈습니다. 