### PR TITLE
[fix] 상태 신고, 개선 사항 요청 글자수 제한 (#314)

### DIFF
--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -18,6 +18,7 @@ import upbrella.be.user.service.UserService;
 import upbrella.be.util.CustomResponse;
 
 import javax.servlet.http.HttpSession;
+import javax.validation.Valid;
 
 @RestController
 @RequiredArgsConstructor
@@ -63,7 +64,7 @@ public class RentController {
     }
 
     @PostMapping("/rent")
-    public ResponseEntity<CustomResponse> rentUmbrellaByUser(@RequestBody RentUmbrellaByUserRequest rentUmbrellaByUserRequest, HttpSession httpSession) {
+    public ResponseEntity<CustomResponse> rentUmbrellaByUser(@RequestBody @Valid RentUmbrellaByUserRequest rentUmbrellaByUserRequest, HttpSession httpSession) {
 
         SessionUser user = (SessionUser) httpSession.getAttribute("user");
         User userToRent = userService.findUserById(user.getId());
@@ -80,7 +81,7 @@ public class RentController {
     }
 
     @PatchMapping("/rent")
-    public ResponseEntity<CustomResponse> returnUmbrellaByUser(@RequestBody ReturnUmbrellaByUserRequest returnUmbrellaByUserRequest, HttpSession httpSession) {
+    public ResponseEntity<CustomResponse> returnUmbrellaByUser(@RequestBody @Valid ReturnUmbrellaByUserRequest returnUmbrellaByUserRequest, HttpSession httpSession) {
 
         SessionUser user = (SessionUser) httpSession.getAttribute("user");
         User userToReturn = userService.findUserById(user.getId());

--- a/src/main/java/upbrella/be/rent/dto/request/RentUmbrellaByUserRequest.java
+++ b/src/main/java/upbrella/be/rent/dto/request/RentUmbrellaByUserRequest.java
@@ -2,6 +2,8 @@ package upbrella.be.rent.dto.request;
 
 import lombok.*;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,5 +13,7 @@ public class RentUmbrellaByUserRequest {
     private String region;
     private long storeId;
     private long umbrellaId;
+
+    @Size(max = 400, message = "conditionReport는 최대 400자여야 합니다.")
     private String conditionReport;
 }

--- a/src/main/java/upbrella/be/rent/dto/request/ReturnUmbrellaByUserRequest.java
+++ b/src/main/java/upbrella/be/rent/dto/request/ReturnUmbrellaByUserRequest.java
@@ -2,6 +2,8 @@ package upbrella.be.rent.dto.request;
 
 import lombok.*;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -11,5 +13,7 @@ public class ReturnUmbrellaByUserRequest {
     private long returnStoreId;
     private String bank;
     private String accountNumber;
+
+    @Size(max = 400, message = "최대 400자여야 합니다.")
     private String improvementReportContent;
 }


### PR DESCRIPTION
## 🟢 구현내용
- #314 
- 상태 신고와 개선 사향 요청의 글자 수를 제한했습니다.

## 🧩 고민과 해결과정
- 조금 더 효율적으로 처리하고 사용자에게 안내를 해주기 위해 프론트 파트에도 place holder를 이용해 명시를 하는 것으로 논의했습니다.