### PR TITLE
협업지점 버그 수정

### DIFF
--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -113,3 +113,8 @@ include::{snippets}/store-find-all-business-hours-doc/http-request.adoc[]
 
 ==== HTTP Response
 include::{snippets}/store-find-all-business-hours-doc/http-response.adoc[]
+
+
+=== 협업지점 영업시간 등록
+==== HTTP Request
+include::{snippets}/store-create-business-hour-doc/http-request.adoc[]

--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -118,3 +118,9 @@ include::{snippets}/store-find-all-business-hours-doc/http-response.adoc[]
 === 협업지점 영업시간 등록
 ==== HTTP Request
 include::{snippets}/store-create-business-hour-doc/http-request.adoc[]
+
+
+=== 협업지점 삭제
+==== HTTP Request
+include::{snippets}/store-delete-business-hour-doc/http-request.adoc[]
+include::{snippets}/store-delete-business-hour-doc/path-parameters.adoc[]

--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -97,3 +97,11 @@ include::{snippets}/store-update-activate-status-doc/path-parameters.adoc[]
 === 협업지점 비활성화
 include::{snippets}/store-update-inactivate-status-doc/http-request.adoc[]
 include::{snippets}/store-update-inactivate-status-doc/path-parameters.adoc[]
+
+=== 협업지점 이미지 조회
+==== HTTP Request
+include::{snippets}/store-find-all-images-doc/http-request.adoc[]
+include::{snippets}/store-find-all-images-doc/path-parameters.adoc[]
+
+==== HTTP Response
+include::{snippets}/store-find-all-images-doc/http-response.adoc[]

--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -105,3 +105,11 @@ include::{snippets}/store-find-all-images-doc/path-parameters.adoc[]
 
 ==== HTTP Response
 include::{snippets}/store-find-all-images-doc/http-response.adoc[]
+
+
+=== 협업지점 영업시간 조회
+==== HTTP Request
+include::{snippets}/store-find-all-business-hours-doc/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/store-find-all-business-hours-doc/http-response.adoc[]

--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -105,22 +105,26 @@ include::{snippets}/store-find-all-images-doc/path-parameters.adoc[]
 
 ==== HTTP Response
 include::{snippets}/store-find-all-images-doc/http-response.adoc[]
+include::{snippets}/store-find-all-images-doc/response-fields-data.adoc[]
 
 
 === 협업지점 영업시간 조회
 ==== HTTP Request
+include::{snippets}/store-find-all-business-hours-doc/path-parameters.adoc[]
 include::{snippets}/store-find-all-business-hours-doc/http-request.adoc[]
 
 ==== HTTP Response
 include::{snippets}/store-find-all-business-hours-doc/http-response.adoc[]
-
+include::{snippets}/store-find-all-business-hours-doc/response-fields-data.adoc[]
 
 === 협업지점 영업시간 등록
 ==== HTTP Request
 include::{snippets}/store-create-business-hour-doc/http-request.adoc[]
+include::{snippets}/store-create-business-hour-doc/request-fields.adoc[]
+include::{snippets}/store-find-all-business-hours-doc/path-parameters.adoc[]
 
 
-=== 협업지점 삭제
+=== 협업지점 영업시간 삭제
 ==== HTTP Request
 include::{snippets}/store-delete-business-hour-doc/http-request.adoc[]
 include::{snippets}/store-delete-business-hour-doc/path-parameters.adoc[]

--- a/src/docs/asciidoc/api/admin/store.adoc
+++ b/src/docs/asciidoc/api/admin/store.adoc
@@ -116,15 +116,3 @@ include::{snippets}/store-find-all-business-hours-doc/http-request.adoc[]
 ==== HTTP Response
 include::{snippets}/store-find-all-business-hours-doc/http-response.adoc[]
 include::{snippets}/store-find-all-business-hours-doc/response-fields-data.adoc[]
-
-=== 협업지점 영업시간 등록
-==== HTTP Request
-include::{snippets}/store-create-business-hour-doc/http-request.adoc[]
-include::{snippets}/store-create-business-hour-doc/request-fields.adoc[]
-include::{snippets}/store-find-all-business-hours-doc/path-parameters.adoc[]
-
-
-=== 협업지점 영업시간 삭제
-==== HTTP Request
-include::{snippets}/store-delete-business-hour-doc/http-request.adoc[]
-include::{snippets}/store-delete-business-hour-doc/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
-import upbrella.be.store.dto.request.CreateClassificationRequest;
-import upbrella.be.store.dto.request.CreateStoreRequest;
-import upbrella.be.store.dto.request.CreateSubClassificationRequest;
-import upbrella.be.store.dto.request.UpdateStoreRequest;
+import upbrella.be.store.dto.request.*;
 import upbrella.be.store.dto.response.*;
 import upbrella.be.store.service.*;
 import upbrella.be.util.CustomResponse;
@@ -296,5 +293,33 @@ public class StoreController {
                         200,
                         "협업지점 영업시간 전체 조회 성공",
                         businessHourService.findAllBusinessHours(storeId)));
+    }
+
+    @PostMapping("/admin/stores/{storeId}/businessHours")
+    public ResponseEntity<CustomResponse> createBusinessHour(@PathVariable long storeId, @RequestBody SingleBusinessHourRequest businessHour) {
+
+        businessHourService.createBusinessHour(storeId, businessHour);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "새로운 영업시간 등록 성공"
+                ));
+    }
+
+    @DeleteMapping("/admin/stores/businessHours/{businessHourId}")
+    public ResponseEntity<CustomResponse> deleteBusinessHour(@PathVariable long businessHourId) {
+
+        businessHourService.deleteBusinessHour(businessHourId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "새로운 영업시간 등록 성공"
+                ));
     }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -112,19 +112,15 @@ public class StoreController {
     @GetMapping("/admin/stores/{storeId}/images")
     public ResponseEntity<CustomResponse<AllImageUrlResponse>> findAllImages(@PathVariable Long storeId) {
 
-        AllImageUrlResponse allImages = storeImageService.findAllImages(storeId);
-
         return ResponseEntity
                 .ok()
                 .body(new CustomResponse<>(
                         "success",
                         200,
                         "협업지점 이미지 전체 조회 성공",
-                        allImages
+                        storeImageService.findAllImages(storeId)
                 ));
     }
-
-
 
     @PostMapping(value = "/admin/stores/{storeId}/images", consumes = {"multipart/form-data"})
     public ResponseEntity<CustomResponse> uploadStoreImage(@RequestPart MultipartFile image, @PathVariable long storeId) {

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -9,10 +9,7 @@ import upbrella.be.store.dto.request.CreateStoreRequest;
 import upbrella.be.store.dto.request.CreateSubClassificationRequest;
 import upbrella.be.store.dto.request.UpdateStoreRequest;
 import upbrella.be.store.dto.response.*;
-import upbrella.be.store.service.ClassificationService;
-import upbrella.be.store.service.StoreDetailService;
-import upbrella.be.store.service.StoreImageService;
-import upbrella.be.store.service.StoreMetaService;
+import upbrella.be.store.service.*;
 import upbrella.be.util.CustomResponse;
 
 import java.time.LocalDateTime;
@@ -26,6 +23,7 @@ public class StoreController {
     private final StoreMetaService storeMetaService;
     private final ClassificationService classificationService;
     private final StoreDetailService storeDetailService;
+    private final BusinessHourService businessHourService;
 
     @GetMapping("/stores/{storeId}")
     public ResponseEntity<CustomResponse<StoreFindByIdResponse>> findStoreById(@PathVariable long storeId) {
@@ -286,5 +284,17 @@ public class StoreController {
                         200,
                         "협업지점 비활성화 성공"
                 ));
+    }
+
+    @GetMapping("/admin/stores/{storeId}/businessHours")
+    public ResponseEntity<CustomResponse<AllBusinessHourResponse>> findAllBusinessHours(@PathVariable long storeId) {
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "협업지점 영업시간 전체 조회 성공",
+                        businessHourService.findAllBusinessHours(storeId)));
     }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -294,32 +294,4 @@ public class StoreController {
                         "협업지점 영업시간 전체 조회 성공",
                         businessHourService.findAllBusinessHours(storeId)));
     }
-
-    @PostMapping("/admin/stores/{storeId}/businessHours")
-    public ResponseEntity<CustomResponse> createBusinessHour(@PathVariable long storeId, @RequestBody SingleBusinessHourRequest businessHour) {
-
-        businessHourService.createBusinessHour(storeId, businessHour);
-
-        return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "새로운 영업시간 등록 성공"
-                ));
-    }
-
-    @DeleteMapping("/admin/stores/businessHours/{businessHourId}")
-    public ResponseEntity<CustomResponse> deleteBusinessHour(@PathVariable long businessHourId) {
-
-        businessHourService.deleteBusinessHour(businessHourId);
-
-        return ResponseEntity
-                .ok()
-                .body(new CustomResponse<>(
-                        "success",
-                        200,
-                        "영업시간 삭제 성공"
-                ));
-    }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -109,6 +109,23 @@ public class StoreController {
                 ));
     }
 
+    @GetMapping("/admin/stores/{storeId}/images")
+    public ResponseEntity<CustomResponse<AllImageUrlResponse>> findAllImages(@PathVariable Long storeId) {
+
+        AllImageUrlResponse allImages = storeImageService.findAllImages(storeId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "협업지점 이미지 전체 조회 성공",
+                        allImages
+                ));
+    }
+
+
+
     @PostMapping(value = "/admin/stores/{storeId}/images", consumes = {"multipart/form-data"})
     public ResponseEntity<CustomResponse> uploadStoreImage(@RequestPart MultipartFile image, @PathVariable long storeId) {
 

--- a/src/main/java/upbrella/be/store/controller/StoreController.java
+++ b/src/main/java/upbrella/be/store/controller/StoreController.java
@@ -319,7 +319,7 @@ public class StoreController {
                 .body(new CustomResponse<>(
                         "success",
                         200,
-                        "새로운 영업시간 등록 성공"
+                        "영업시간 삭제 성공"
                 ));
     }
 }

--- a/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
+++ b/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
@@ -96,4 +96,15 @@ public class StoreExceptionHandler {
                         400,
                         ex.getMessage()));
     }
+
+    @ExceptionHandler(NotExistBusinessHourException.class)
+    public ResponseEntity<CustomErrorResponse> notExistBusinessHour(NotExistBusinessHourException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "not found",
+                        404,
+                        ex.getMessage()));
+    }
 }

--- a/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
@@ -4,6 +4,7 @@ import lombok.*;
 import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 @Getter
 @Builder
@@ -33,4 +34,5 @@ public class UpdateStoreRequest {
     private double longitude;
     private String content;
     private String password;
+    private List<SingleBusinessHourRequest> businessHours;
 }

--- a/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/UpdateStoreRequest.java
@@ -4,7 +4,6 @@ import lombok.*;
 import org.hibernate.validator.constraints.Range;
 
 import javax.validation.constraints.NotBlank;
-import java.util.List;
 
 @Getter
 @Builder
@@ -34,5 +33,4 @@ public class UpdateStoreRequest {
     private double longitude;
     private String content;
     private String password;
-    private List<SingleBusinessHourRequest> businessHours;
 }

--- a/src/main/java/upbrella/be/store/dto/response/AllImageUrlResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/AllImageUrlResponse.java
@@ -1,0 +1,21 @@
+package upbrella.be.store.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class AllImageUrlResponse {
+
+    private Long storeId;
+    private List<SingleImageUrlResponse> images;
+
+    public static AllImageUrlResponse of(Long storeId, List<SingleImageUrlResponse> images) {
+        return AllImageUrlResponse.builder()
+                .storeId(storeId)
+                .images(images)
+                .build();
+    }
+}

--- a/src/main/java/upbrella/be/store/dto/response/SingleBusinessHourResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleBusinessHourResponse.java
@@ -20,6 +20,7 @@ import java.time.LocalTime;
 @AllArgsConstructor
 public class SingleBusinessHourResponse {
 
+    private long id;
     private DayOfWeek date;
     @JsonSerialize(using = LocalTimeSerializer.class)
     @JsonDeserialize(using = LocalTimeDeserializer.class)
@@ -33,6 +34,7 @@ public class SingleBusinessHourResponse {
     public static SingleBusinessHourResponse createSingleHourResponse(BusinessHour businessHour) {
 
             return SingleBusinessHourResponse.builder()
+                    .id(businessHour.getId())
                     .date(businessHour.getDate())
                     .openAt(businessHour.getOpenAt())
                     .closeAt(businessHour.getCloseAt())

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 import upbrella.be.store.entity.StoreDetail;
 
@@ -20,7 +21,6 @@ public class SingleStoreResponse implements Serializable {
     private boolean activateStatus;
     private String address;
     private String addressDetail;
-    private String thumbnail;
     private String umbrellaLocation;
     private String businessHour;
     private String contactNumber;
@@ -28,11 +28,9 @@ public class SingleStoreResponse implements Serializable {
     private double latitude;
     private double longitude;
     private String content;
-    private List<SingleImageUrlResponse> imageUrls;
     private String password;
-    private List<SingleBusinessHourResponse> businessHours;
 
-    public static SingleStoreResponse ofCreateSingleStoreResponse(StoreDetail storeDetail, String thumbnail, List<SingleImageUrlResponse> images, List<SingleBusinessHourResponse> businessHours) {
+    public static SingleStoreResponse ofCreateSingleStoreResponse(StoreDetail storeDetail) {
 
         return SingleStoreResponse.builder()
                 .id(storeDetail.getStoreMeta().getId())
@@ -51,9 +49,6 @@ public class SingleStoreResponse implements Serializable {
                 .longitude(storeDetail.getStoreMeta().getLongitude())
                 .content(storeDetail.getContent())
                 .password(storeDetail.getStoreMeta().getPassword())
-                .imageUrls(images)
-                .thumbnail(thumbnail)
-                .businessHours(businessHours)
                 .build();
     }
 }

--- a/src/main/java/upbrella/be/store/entity/BusinessHour.java
+++ b/src/main/java/upbrella/be/store/entity/BusinessHour.java
@@ -37,17 +37,7 @@ public class BusinessHour {
 
     public void updateBusinessHour(SingleBusinessHourRequest businessHour) {
 
-        this.date = businessHour.getDate();
         this.openAt = businessHour.getOpenAt();
         this.closeAt = businessHour.getCloseAt();
-    }
-
-    public static BusinessHour createBusinessHour(Long storeId, SingleBusinessHourRequest businessHour) {
-        return BusinessHour.builder()
-                .storeMeta(StoreMeta.builder().id(storeId).build())
-                .date(businessHour.getDate())
-                .openAt(businessHour.getOpenAt())
-                .closeAt(businessHour.getCloseAt())
-                .build();
     }
 }

--- a/src/main/java/upbrella/be/store/entity/BusinessHour.java
+++ b/src/main/java/upbrella/be/store/entity/BusinessHour.java
@@ -41,4 +41,13 @@ public class BusinessHour {
         this.openAt = businessHour.getOpenAt();
         this.closeAt = businessHour.getCloseAt();
     }
+
+    public static BusinessHour createBusinessHour(Long storeId, SingleBusinessHourRequest businessHour) {
+        return BusinessHour.builder()
+                .storeMeta(StoreMeta.builder().id(storeId).build())
+                .date(businessHour.getDate())
+                .openAt(businessHour.getOpenAt())
+                .closeAt(businessHour.getCloseAt())
+                .build();
+    }
 }

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -6,9 +6,7 @@ import upbrella.be.store.dto.request.UpdateStoreRequest;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 
 
 @Entity
@@ -52,7 +50,7 @@ public class StoreMeta {
                 .build();
     }
 
-    public static StoreMeta createStoreMetaForUpdate(UpdateStoreRequest request, Classification classification, Classification subClassification, List<BusinessHour> businessHours) {
+    public static StoreMeta createStoreMetaForUpdate(UpdateStoreRequest request, Classification classification, Classification subClassification) {
 
         return StoreMeta.builder()
                 .name(request.getName())
@@ -63,7 +61,6 @@ public class StoreMeta {
                 .latitude(request.getLatitude())
                 .longitude(request.getLongitude())
                 .password(request.getPassword())
-                .businessHours(businessHours)
                 .build();
     }
 

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -35,7 +35,7 @@ public class StoreMeta {
     private double longitude;
     private String password;
     @OneToMany(mappedBy = "storeMeta", cascade = CascadeType.ALL)
-    private Set<BusinessHour> businessHours;
+    private List<BusinessHour> businessHours;
 
     public static StoreMeta createStoreMetaForSave(CreateStoreRequest request, Classification classification, Classification subClassification) {
 
@@ -63,7 +63,7 @@ public class StoreMeta {
                 .latitude(request.getLatitude())
                 .longitude(request.getLongitude())
                 .password(request.getPassword())
-                .businessHours(new HashSet<>(businessHours))
+                .businessHours(businessHours)
                 .build();
     }
 
@@ -88,7 +88,7 @@ public class StoreMeta {
 
     public boolean isOpenStore(LocalDateTime currentTime) {
 
-        Set<BusinessHour> businessHours = this.getBusinessHours();
+        List<BusinessHour> businessHours = this.getBusinessHours();
 
         return businessHours.stream()
                 .filter(businessHour -> businessHour.getDate().equals(currentTime.getDayOfWeek()))

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -32,7 +32,7 @@ public class StoreMeta {
     private double latitude;
     private double longitude;
     private String password;
-    @OneToMany(mappedBy = "storeMeta", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "storeMeta")
     private List<BusinessHour> businessHours;
 
     public static StoreMeta createStoreMetaForSave(CreateStoreRequest request, Classification classification, Classification subClassification) {
@@ -75,7 +75,6 @@ public class StoreMeta {
         this.latitude = storeMeta.getLatitude();
         this.longitude = storeMeta.getLongitude();
         this.password = storeMeta.getPassword();
-        this.businessHours = storeMeta.getBusinessHours();
     }
 
     public void delete() {

--- a/src/main/java/upbrella/be/store/exception/NotExistBusinessHourException.java
+++ b/src/main/java/upbrella/be/store/exception/NotExistBusinessHourException.java
@@ -1,0 +1,9 @@
+package upbrella.be.store.exception;
+
+public class NotExistBusinessHourException extends RuntimeException{
+
+    public NotExistBusinessHourException(String message) {
+
+        super(message);
+    }
+}

--- a/src/main/java/upbrella/be/store/repository/BusinessHourRepository.java
+++ b/src/main/java/upbrella/be/store/repository/BusinessHourRepository.java
@@ -8,4 +8,6 @@ import java.util.List;
 public interface BusinessHourRepository extends JpaRepository<BusinessHour, Long> {
 
     List<BusinessHour> findByStoreMetaId(Long storeMetaId);
+
+    void deleteAllByStoreMetaId(Long storeMetaId);
 }

--- a/src/main/java/upbrella/be/store/repository/StoreDetailRepository.java
+++ b/src/main/java/upbrella/be/store/repository/StoreDetailRepository.java
@@ -3,6 +3,10 @@ package upbrella.be.store.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import upbrella.be.store.entity.StoreDetail;
 
+import java.util.Optional;
+
 
 public interface StoreDetailRepository extends JpaRepository<StoreDetail, Long>, StoreDetailRepositoryCustom {
+
+    Optional<StoreDetail> findStoreDetailByStoreMetaId(long storeMetaId);
 }

--- a/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryImpl.java
+++ b/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryImpl.java
@@ -7,7 +7,6 @@ import upbrella.be.store.entity.StoreDetail;
 import java.util.List;
 import java.util.Optional;
 
-import static upbrella.be.store.entity.QBusinessHour.businessHour;
 import static upbrella.be.store.entity.QClassification.classification;
 import static upbrella.be.store.entity.QStoreDetail.storeDetail;
 import static upbrella.be.store.entity.QStoreImage.storeImage;
@@ -26,8 +25,6 @@ public class StoreDetailRepositoryImpl implements StoreDetailRepositoryCustom {
                 .join(storeDetail.storeMeta, storeMeta).fetchJoin()
                 .join(storeMeta.classification, classification).fetchJoin()
                 .join(storeMeta.subClassification, classification).fetchJoin()
-                .leftJoin(storeMeta.businessHours, businessHour).fetchJoin()
-                .leftJoin(storeDetail.storeImages, storeImage).fetchJoin()
                 .where(storeMeta.deleted.isFalse())
                 .distinct()
                 .fetch();

--- a/src/main/java/upbrella/be/store/service/BusinessHourService.java
+++ b/src/main/java/upbrella/be/store/service/BusinessHourService.java
@@ -50,11 +50,25 @@ public class BusinessHourService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public AllBusinessHourResponse findAllBusinessHours(Long storeId) {
 
         List<BusinessHour> businessHours = findBusinessHourByStoreMetaId(storeId);
         return AllBusinessHourResponse.builder()
                 .businessHours(createBusinessHourResponse(businessHours))
                 .build();
+    }
+
+    @Transactional
+    public void createBusinessHour(Long storeId, SingleBusinessHourRequest businessHour) {
+
+            BusinessHour newBusinessHour = BusinessHour.createBusinessHour(storeId, businessHour);
+            businessHourRepository.save(newBusinessHour);
+    }
+
+    @Transactional
+    public void deleteBusinessHour(Long businessHourId) {
+
+        businessHourRepository.deleteById(businessHourId);
     }
 }

--- a/src/main/java/upbrella/be/store/service/BusinessHourService.java
+++ b/src/main/java/upbrella/be/store/service/BusinessHourService.java
@@ -7,6 +7,7 @@ import upbrella.be.store.dto.request.SingleBusinessHourRequest;
 import upbrella.be.store.dto.response.AllBusinessHourResponse;
 import upbrella.be.store.dto.response.SingleBusinessHourResponse;
 import upbrella.be.store.entity.BusinessHour;
+import upbrella.be.store.exception.NotExistBusinessHourException;
 import upbrella.be.store.repository.BusinessHourRepository;
 
 import java.util.Comparator;
@@ -68,6 +69,10 @@ public class BusinessHourService {
 
     @Transactional
     public void deleteBusinessHour(Long businessHourId) {
+
+        if (!businessHourRepository.existsById(businessHourId)) {
+            throw new NotExistBusinessHourException("[ERROR] 해당 시간대가 존재하지 않습니다.");
+        }
 
         businessHourRepository.deleteById(businessHourId);
     }

--- a/src/main/java/upbrella/be/store/service/BusinessHourService.java
+++ b/src/main/java/upbrella/be/store/service/BusinessHourService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.store.dto.request.SingleBusinessHourRequest;
+import upbrella.be.store.dto.response.AllBusinessHourResponse;
 import upbrella.be.store.dto.response.SingleBusinessHourResponse;
 import upbrella.be.store.entity.BusinessHour;
 import upbrella.be.store.repository.BusinessHourRepository;
@@ -47,5 +48,13 @@ public class BusinessHourService {
                 .map(SingleBusinessHourResponse::createSingleHourResponse)
                 .sorted(Comparator.comparing(SingleBusinessHourResponse::getDate))
                 .collect(Collectors.toList());
+    }
+
+    public AllBusinessHourResponse findAllBusinessHours(Long storeId) {
+
+        List<BusinessHour> businessHours = findBusinessHourByStoreMetaId(storeId);
+        return AllBusinessHourResponse.builder()
+                .businessHours(createBusinessHourResponse(businessHours))
+                .build();
     }
 }

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import upbrella.be.store.dto.request.UpdateStoreRequest;
 import upbrella.be.store.dto.response.*;
-import upbrella.be.store.entity.BusinessHour;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.StoreDetail;
 import upbrella.be.store.entity.StoreMeta;

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -77,15 +77,7 @@ public class StoreDetailService {
 
     private SingleStoreResponse createSingleStoreResponse(StoreDetail storeDetail) {
 
-        List<SingleImageUrlResponse> sortedImageUrls = storeDetail.getSortedStoreImages().stream()
-                .map(SingleImageUrlResponse::createImageUrlResponse)
-                .collect(Collectors.toList());
-
-        String thumbnail = storeImageService.createThumbnail(sortedImageUrls);
-        Set<BusinessHour> businessHourSet = storeDetail.getStoreMeta().getBusinessHours();
-        List<BusinessHour> businessHourList = new ArrayList<>(businessHourSet);
-        List<SingleBusinessHourResponse> businessHours = businessHourService.createBusinessHourResponse(businessHourList);
-        return SingleStoreResponse.ofCreateSingleStoreResponse(storeDetail, thumbnail, sortedImageUrls, businessHours);
+        return SingleStoreResponse.ofCreateSingleStoreResponse(storeDetail);
     }
 
     @Transactional

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -41,6 +41,8 @@ public class StoreDetailService {
 
         foundStoreMeta.updateStoreMeta(storeMetaForUpdate);
         storeDetailById.updateStore(foundStoreMeta, request);
+
+        businessHourService.updateBusinessHours(foundStoreMeta, request.getBusinessHours());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -99,7 +99,7 @@ public class StoreDetailService {
         storeDetailRepository.save(storeDetail);
     }
 
-    public StoreDetail findByStoreMetaID(Long storeId) {
+    public StoreDetail findByStoreMetaId(Long storeId) {
 
         return storeDetailRepository.findStoreDetailByStoreMetaId(storeId)
                 .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 존재하지 않는 가게입니다."));

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -33,18 +33,14 @@ public class StoreDetailService {
     public void updateStore(Long storeId, UpdateStoreRequest request) {
 
         StoreDetail storeDetailById = findStoreDetailByStoreMetaId(storeId);
-        long storeMetaId = storeDetailById.getStoreMeta().getId();
 
         Classification classification = classificationService.findClassificationById(request.getClassificationId());
         Classification subClassification = classificationService.findSubClassificationById(request.getSubClassificationId());
 
-        List<BusinessHour> businessHours = businessHourService.updateBusinessHour(storeMetaId, request.getBusinessHours());
-
-        StoreMeta storeMetaForUpdate = StoreMeta.createStoreMetaForUpdate(request, classification, subClassification, businessHours);
-
+        StoreMeta storeMetaForUpdate = StoreMeta.createStoreMetaForUpdate(request, classification, subClassification);
         StoreMeta foundStoreMeta = storeDetailById.getStoreMeta();
-        foundStoreMeta.updateStoreMeta(storeMetaForUpdate);
 
+        foundStoreMeta.updateStoreMeta(storeMetaForUpdate);
         storeDetailById.updateStore(foundStoreMeta, request);
     }
 

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -102,4 +102,10 @@ public class StoreDetailService {
 
         storeDetailRepository.save(storeDetail);
     }
+
+    public StoreDetail findByStoreMetaID(Long storeId) {
+
+        return storeDetailRepository.findStoreDetailByStoreMetaId(storeId)
+                .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 존재하지 않는 가게입니다."));
+    }
 }

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -96,7 +96,7 @@ public class StoreImageService {
 
     public AllImageUrlResponse findAllImages(long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findByStoreMetaID(storeId);
+        StoreDetail storeDetail = storeDetailService.findByStoreMetaId(storeId);
 
         return AllImageUrlResponse.of(storeId, storeDetail.getStoreImages().stream()
                 .map(SingleImageUrlResponse::createImageUrlResponse)
@@ -117,7 +117,7 @@ public class StoreImageService {
 
     private void saveStoreImage(String imageUrl, long storeId) {
 
-        StoreDetail storeDetail = storeDetailService.findByStoreMetaID(storeId);
+        StoreDetail storeDetail = storeDetailService.findByStoreMetaId(storeId);
         storeImageRepository.save(StoreImage.createStoreImage(storeDetail, imageUrl));
     }
 

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -10,6 +10,7 @@ import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import upbrella.be.store.dto.response.AllImageUrlResponse;
 import upbrella.be.store.dto.response.SingleImageUrlResponse;
 import upbrella.be.store.entity.StoreDetail;
 import upbrella.be.store.entity.StoreImage;
@@ -85,6 +86,11 @@ public class StoreImageService {
     public String makeRandomId() {
 
         return UUID.randomUUID().toString().substring(0, 10);
+    }
+
+    public AllImageUrlResponse findAllImages(long storeId) {
+
+        return null;
     }
 
     private void deleteFileInS3(String imgUrl) {

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -66,7 +66,7 @@ public class StoreMetaService {
 
     private boolean isOpenStore(StoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount, LocalDateTime currentTime) {
 
-        Set<BusinessHour> businessHours = storeMetaWithUmbrellaCount.getStoreMeta().getBusinessHours();
+        List<BusinessHour> businessHours = storeMetaWithUmbrellaCount.getStoreMeta().getBusinessHours();
 
         return businessHours.stream()
                 .filter(businessHour -> businessHour.getDate().equals(currentTime.getDayOfWeek()))

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -928,14 +928,41 @@ class StoreControllerTest extends RestDocsSupport {
 
     @Test
     @DisplayName("협업지점의 영업시간들을 조회할 수 있다.")
-    void findAllBusinessHours() {
+    void findAllBusinessHours() throws Exception {
         // given
-
+        given(businessHourService.findAllBusinessHours(1L))
+                .willReturn(AllBusinessHourResponse.builder()
+                        .businessHours(List.of(SingleBusinessHourResponse.builder()
+                                .date(DayOfWeek.MONDAY)
+                                .openAt(LocalTime.of(10, 0))
+                                .closeAt(LocalTime.of(20, 0))
+                                .build()))
+                        .build());
 
         // when
-
+        businessHourService.findAllBusinessHours(1L);
 
         // then
-
+        mockMvc.perform(
+                        get("/admin/stores/{storeId}/businessHours", 1L)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-find-all-business-hours-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("storeId").description("협업 지점 고유번호")
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("businessHours[]").type(JsonFieldType.ARRAY)
+                                        .description("협업 지점 영업시간 목록"),
+                                fieldWithPath("businessHours[].date").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 요일"),
+                                fieldWithPath("businessHours[].openAt").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 오픈시간"),
+                                fieldWithPath("businessHours[].closeAt").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 마감시간")
+                        )));
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -937,9 +937,9 @@ class StoreControllerTest extends RestDocsSupport {
 
         // then
         mockMvc.perform(
-                post("/admin/stores/{storeId}/businessHours", 1L)
-                        .content(objectMapper.writeValueAsString(request))
-                        .contentType(MediaType.APPLICATION_JSON)
+                        post("/admin/stores/{storeId}/businessHours", 1L)
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
                 )
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -956,6 +956,29 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("협업 지점 영업시간 오픈시간"),
                                 fieldWithPath("closeAt").type(JsonFieldType.STRING)
                                         .description("협업 지점 영업시간 마감시간")
+                        )));
+
+    }
+
+    @Test
+    @DisplayName("협업지점 영업시간 삭제 테스트")
+    void deleteBusinessHour() throws Exception {
+        // given
+
+
+        // when
+
+
+        // then
+        mockMvc.perform(
+                        delete("/admin/stores/businessHours/{businessHourId}", 1L)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-delete-business-hour-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("businessHourId").description("협업 지점 영업시간 고유번호")
                         )));
 
     }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -14,6 +14,7 @@ import upbrella.be.store.dto.request.*;
 import upbrella.be.store.dto.response.*;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.ClassificationType;
+import upbrella.be.store.entity.StoreDetail;
 import upbrella.be.store.service.*;
 
 import java.time.DayOfWeek;
@@ -850,8 +851,8 @@ class StoreControllerTest extends RestDocsSupport {
 
         // then
         mockMvc.perform(
-                patch("/admin/stores/{storeId}/activate", storeId)
-        ).andDo(print())
+                        patch("/admin/stores/{storeId}/activate", storeId)
+                ).andDo(print())
                 .andExpect(status().isOk())
                 .andDo(document("store-update-activate-status-doc",
                         getDocumentRequest(),
@@ -882,5 +883,59 @@ class StoreControllerTest extends RestDocsSupport {
                         pathParameters(
                                 parameterWithName("storeId").description("협업 지점 고유번호")
                         )));
+    }
+
+    @Test
+    @DisplayName("협업지점의 이미지들을 조회할 수 있다.")
+    void findAllImages() throws Exception {
+        // given
+        given(storeImageService.findAllImages(1L))
+                .willReturn(AllImageUrlResponse
+                        .builder()
+                        .storeId(1L)
+                        .images(List.of(SingleImageUrlResponse.builder()
+                                .id(1L)
+                                .imageUrl("url")
+                                .build()))
+                        .build());
+
+        // when
+        storeImageService.findAllImages(1L);
+
+        // then
+        mockMvc.perform(
+                        get("/admin/stores/{storeId}/images", 1L)
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-find-all-images-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("storeId").description("협업 지점 고유번호")
+                        ),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("storeId").type(JsonFieldType.NUMBER)
+                                        .description("협업 지점 고유번호"),
+                                fieldWithPath("images[]").type(JsonFieldType.ARRAY)
+                                        .description("협업 지점 이미지 목록"),
+                                fieldWithPath("images[].id").type(JsonFieldType.NUMBER)
+                                        .description("협업 지점 이미지 고유번호"),
+                                fieldWithPath("images[].imageUrl").type(JsonFieldType.STRING)
+                                        .description("협업 지점 이미지 URL")
+                        )));
+    }
+
+    @Test
+    @DisplayName("협업지점의 영업시간들을 조회할 수 있다.")
+    void findAllBusinessHours() {
+        // given
+
+
+        // when
+
+
+        // then
+
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -441,6 +441,13 @@ class StoreControllerTest extends RestDocsSupport {
                 .longitude(33.33)
                 .content("내용")
                 .password("비밀번호")
+                .businessHours(List.of(
+                        SingleBusinessHourRequest.builder()
+                                .date(DayOfWeek.MONDAY)
+                                .openAt(LocalTime.of(10, 0))
+                                .closeAt(LocalTime.of(20, 0))
+                                .build()
+                ))
                 .build();
         long storeId = 1L;
 
@@ -492,7 +499,16 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("내용"),
                                 fieldWithPath("password").type(JsonFieldType.STRING)
                                         .description("비밀번호")
-                                        .optional()
+                                        .optional(),
+                                fieldWithPath("businessHours").type(JsonFieldType.ARRAY)
+                                        .description("영업 시간")
+                                        .optional(),
+                                fieldWithPath("businessHours[].date").type(JsonFieldType.STRING)
+                                        .description("영업 요일"),
+                                fieldWithPath("businessHours[].openAt").type(JsonFieldType.STRING)
+                                        .description("오픈 시간"),
+                                fieldWithPath("businessHours[].closeAt").type(JsonFieldType.STRING)
+                                        .description("마감 시간")
                         )));
     }
 
@@ -921,65 +937,5 @@ class StoreControllerTest extends RestDocsSupport {
                                 fieldWithPath("businessHours[].closeAt").type(JsonFieldType.STRING)
                                         .description("협업 지점 영업시간 마감시간")
                         )));
-    }
-
-    @Test
-    @DisplayName("협업지점의 영업시간을 추가할 수 있다.")
-    void createBusinessHourTest() throws Exception {
-        // given
-        SingleBusinessHourRequest request = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.MONDAY)
-                .openAt(LocalTime.of(10, 0))
-                .closeAt(LocalTime.of(20, 0))
-                .build();
-        // when
-
-
-        // then
-        mockMvc.perform(
-                        post("/admin/stores/{storeId}/businessHours", 1L)
-                                .content(objectMapper.writeValueAsString(request))
-                                .contentType(MediaType.APPLICATION_JSON)
-                )
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andDo(document("store-create-business-hour-doc",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        pathParameters(
-                                parameterWithName("storeId").description("협업 지점 고유번호")
-                        ),
-                        requestFields(
-                                fieldWithPath("date").type(JsonFieldType.STRING)
-                                        .description("협업 지점 영업시간 요일"),
-                                fieldWithPath("openAt").type(JsonFieldType.STRING)
-                                        .description("협업 지점 영업시간 오픈시간"),
-                                fieldWithPath("closeAt").type(JsonFieldType.STRING)
-                                        .description("협업 지점 영업시간 마감시간")
-                        )));
-
-    }
-
-    @Test
-    @DisplayName("협업지점 영업시간 삭제 테스트")
-    void deleteBusinessHour() throws Exception {
-        // given
-
-
-        // when
-
-
-        // then
-        mockMvc.perform(
-                        delete("/admin/stores/businessHours/{businessHourId}", 1L)
-                ).andDo(print())
-                .andExpect(status().isOk())
-                .andDo(document("store-delete-business-hour-doc",
-                        getDocumentRequest(),
-                        getDocumentResponse(),
-                        pathParameters(
-                                parameterWithName("businessHourId").description("협업 지점 영업시간 고유번호")
-                        )));
-
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -14,10 +14,7 @@ import upbrella.be.store.dto.request.*;
 import upbrella.be.store.dto.response.*;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.ClassificationType;
-import upbrella.be.store.service.ClassificationService;
-import upbrella.be.store.service.StoreDetailService;
-import upbrella.be.store.service.StoreImageService;
-import upbrella.be.store.service.StoreMetaService;
+import upbrella.be.store.service.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;
@@ -47,11 +44,13 @@ class StoreControllerTest extends RestDocsSupport {
     private ClassificationService classificationService;
     @Mock
     private StoreDetailService storeDetailService;
+    @Mock
+    private BusinessHourService businessHourService;
 
     @Override
     protected Object initController() {
 
-        return new StoreController(storeImageService, storeMetaService, classificationService, storeDetailService);
+        return new StoreController(storeImageService, storeMetaService, classificationService, storeDetailService, businessHourService);
     }
 
     @Test

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -14,7 +14,6 @@ import upbrella.be.store.dto.request.*;
 import upbrella.be.store.dto.response.*;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.ClassificationType;
-import upbrella.be.store.entity.StoreDetail;
 import upbrella.be.store.service.*;
 
 import java.time.DayOfWeek;
@@ -442,43 +441,6 @@ class StoreControllerTest extends RestDocsSupport {
                 .longitude(33.33)
                 .content("내용")
                 .password("비밀번호")
-                .businessHours(
-                        List.of(
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.MONDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.TUESDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.WEDNESDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.THURSDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.FRIDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.SATURDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build(),
-                                SingleBusinessHourRequest.builder()
-                                        .date(DayOfWeek.SUNDAY)
-                                        .openAt(LocalTime.of(10, 0))
-                                        .closeAt(LocalTime.of(20, 0))
-                                        .build()))
                 .build();
         long storeId = 1L;
 
@@ -530,15 +492,7 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("내용"),
                                 fieldWithPath("password").type(JsonFieldType.STRING)
                                         .description("비밀번호")
-                                        .optional(),
-                                fieldWithPath("businessHours").type(JsonFieldType.ARRAY)
-                                        .description("영업 시간"),
-                                fieldWithPath("businessHours[].date").type(JsonFieldType.STRING)
-                                        .description("영업 요일"),
-                                fieldWithPath("businessHours[].openAt").type(JsonFieldType.STRING)
-                                        .description("오픈 시간"),
-                                fieldWithPath("businessHours[].closeAt").type(JsonFieldType.STRING)
-                                        .description("마감 시간")
+                                        .optional()
                         )));
     }
 
@@ -933,6 +887,7 @@ class StoreControllerTest extends RestDocsSupport {
         given(businessHourService.findAllBusinessHours(1L))
                 .willReturn(AllBusinessHourResponse.builder()
                         .businessHours(List.of(SingleBusinessHourResponse.builder()
+                                .id(1L)
                                 .date(DayOfWeek.MONDAY)
                                 .openAt(LocalTime.of(10, 0))
                                 .closeAt(LocalTime.of(20, 0))
@@ -955,6 +910,8 @@ class StoreControllerTest extends RestDocsSupport {
                         ),
                         responseFields(
                                 beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("businessHours[].id").type(JsonFieldType.NUMBER)
+                                        .description("협업 지점 고유번호"),
                                 fieldWithPath("businessHours[]").type(JsonFieldType.ARRAY)
                                         .description("협업 지점 영업시간 목록"),
                                 fieldWithPath("businessHours[].date").type(JsonFieldType.STRING)
@@ -964,5 +921,42 @@ class StoreControllerTest extends RestDocsSupport {
                                 fieldWithPath("businessHours[].closeAt").type(JsonFieldType.STRING)
                                         .description("협업 지점 영업시간 마감시간")
                         )));
+    }
+
+    @Test
+    @DisplayName("협업지점의 영업시간을 추가할 수 있다.")
+    void createBusinessHourTest() throws Exception {
+        // given
+        SingleBusinessHourRequest request = SingleBusinessHourRequest.builder()
+                .date(DayOfWeek.MONDAY)
+                .openAt(LocalTime.of(10, 0))
+                .closeAt(LocalTime.of(20, 0))
+                .build();
+        // when
+
+
+        // then
+        mockMvc.perform(
+                post("/admin/stores/{storeId}/businessHours", 1L)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("store-create-business-hour-doc",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("storeId").description("협업 지점 고유번호")
+                        ),
+                        requestFields(
+                                fieldWithPath("date").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 요일"),
+                                fieldWithPath("openAt").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 오픈시간"),
+                                fieldWithPath("closeAt").type(JsonFieldType.STRING)
+                                        .description("협업 지점 영업시간 마감시간")
+                        )));
+
     }
 }

--- a/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/StoreControllerTest.java
@@ -233,57 +233,13 @@ class StoreControllerTest extends RestDocsSupport {
                         .activateStatus(true)
                         .address("주소")
                         .addressDetail("상세주소")
-                        .thumbnail("썸네일")
                         .umbrellaLocation("가게 앞")
                         .businessHour("연중 무휴")
                         .contactNumber("010-0000-0000")
                         .instagramId("instagramId")
                         .latitude(33.33)
                         .longitude(33.33)
-                        .imageUrls(
-                                List.of(SingleImageUrlResponse.builder()
-                                        .id(1L)
-                                        .imageUrl("url")
-                                        .build()))
                         .password("비밀번호")
-                        .businessHours(
-                                List.of(
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.MONDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.TUESDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.WEDNESDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.THURSDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.FRIDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.SATURDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build(),
-                                        SingleBusinessHourResponse.builder()
-                                                .date(DayOfWeek.SUNDAY)
-                                                .openAt(LocalTime.of(10, 0))
-                                                .closeAt(LocalTime.of(20, 0))
-                                                .build())
-                        )
                         .build()));
 
         // when
@@ -334,8 +290,6 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("주소"),
                                 fieldWithPath("stores[].addressDetail").type(JsonFieldType.STRING)
                                         .description("상세 주소"),
-                                fieldWithPath("stores[].thumbnail").type(JsonFieldType.STRING)
-                                        .description("썸네일"),
                                 fieldWithPath("stores[].umbrellaLocation").type(JsonFieldType.STRING)
                                         .description("우산 위치"),
                                 fieldWithPath("stores[].businessHour").type(JsonFieldType.STRING)
@@ -350,22 +304,8 @@ class StoreControllerTest extends RestDocsSupport {
                                         .description("경도"),
                                 fieldWithPath("stores[].content").type(JsonFieldType.STRING)
                                         .description("내용"),
-                                fieldWithPath("stores[].imageUrls").type(JsonFieldType.ARRAY)
-                                        .description("이미지 URL 목록"),
-                                fieldWithPath("stores[].imageUrls[].id").type(JsonFieldType.NUMBER)
-                                        .description("이미지 고유번호"),
-                                fieldWithPath("stores[].imageUrls[].imageUrl").type(JsonFieldType.STRING)
-                                        .description("이미지 URL"),
                                 fieldWithPath("stores[].password").type(JsonFieldType.STRING)
-                                        .description("비밀번호"),
-                                fieldWithPath("stores[].businessHours").type(JsonFieldType.ARRAY)
-                                        .description("영업 시간"),
-                                fieldWithPath("stores[].businessHours[].date").type(JsonFieldType.STRING)
-                                        .description("영업 요일"),
-                                fieldWithPath("stores[].businessHours[].openAt").type(JsonFieldType.STRING)
-                                        .description("오픈 시간"),
-                                fieldWithPath("stores[].businessHours[].closeAt").type(JsonFieldType.STRING)
-                                        .description("마감 시간")
+                                        .description("비밀번호")
                         )));
     }
 

--- a/src/test/java/upbrella/be/store/entity/StoreMetaTest.java
+++ b/src/test/java/upbrella/be/store/entity/StoreMetaTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -48,7 +49,7 @@ class StoreMetaTest {
                 .latitude(33.33)
                 .longitude(33.33)
                 .password("비밀번호")
-                .businessHours(Set.of(businessHour))
+                .businessHours(List.of(businessHour))
                 .build();
 
         // when

--- a/src/test/java/upbrella/be/store/service/BusinessHourServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/BusinessHourServiceTest.java
@@ -14,7 +14,9 @@ import upbrella.be.store.repository.BusinessHourRepository;
 
 import java.time.DayOfWeek;
 import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -148,117 +150,51 @@ class BusinessHourServiceTest {
     @DisplayName("협업지점의 영업시간을 id 를 기준으로 수정할 수 있다.")
     void updateBusinessHourTest() {
         // given
-        BusinessHour monday = BusinessHour.builder()
-                .date(DayOfWeek.MONDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour tuesday = BusinessHour.builder()
-                .date(DayOfWeek.TUESDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour wednesday = BusinessHour.builder()
-                .date(DayOfWeek.WEDNESDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour thursday = BusinessHour.builder()
-                .date(DayOfWeek.THURSDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour friday = BusinessHour.builder()
-                .date(DayOfWeek.FRIDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour saturday = BusinessHour.builder()
-                .date(DayOfWeek.SATURDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
-        BusinessHour sunday = BusinessHour.builder()
-                .date(DayOfWeek.SUNDAY)
-                .openAt(LocalTime.of(9, 0))
-                .closeAt(LocalTime.of(18, 0))
-                .build();
+        List<BusinessHour> businessHours = new ArrayList<>();
+        List<SingleBusinessHourRequest> updateBusinessHours = new ArrayList<>();
 
-        SingleBusinessHourRequest updateMonday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.MONDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
+        // 이전 데이터와 업데이트 데이터를 생성
+        for (DayOfWeek day : DayOfWeek.values()) {
+            businessHours.add(BusinessHour.builder()
+                    .date(day)
+                    .openAt(LocalTime.of(9, 0))
+                    .closeAt(LocalTime.of(18, 0))
+                    .build());
+            updateBusinessHours.add(SingleBusinessHourRequest.builder()
+                    .date(day)
+                    .openAt(LocalTime.of(10, 10))
+                    .closeAt(LocalTime.of(19, 10))
+                    .build());
+        }
 
-        SingleBusinessHourRequest updateTuesday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.TUESDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        SingleBusinessHourRequest updateWednesday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.WEDNESDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        SingleBusinessHourRequest updateThursday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.THURSDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        SingleBusinessHourRequest updateFriday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.FRIDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        SingleBusinessHourRequest updateSaturday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.SATURDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        SingleBusinessHourRequest updateSunday = SingleBusinessHourRequest.builder()
-                .date(DayOfWeek.SUNDAY)
-                .openAt(LocalTime.of(9, 10))
-                .closeAt(LocalTime.of(18, 10))
-                .build();
-
-        List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
-        List<SingleBusinessHourRequest> updateBusinessHours = List.of(updateMonday, updateTuesday, updateWednesday, updateThursday, updateFriday, updateSaturday, updateSunday);
 
         StoreMeta storeMeta = StoreMeta.builder()
                 .id(1L)
                 .businessHours(businessHours)
                 .build();
+
+        given(businessHourRepository.findByStoreMetaId(1L)).willReturn(updateBusinessHours.stream()
+                .map(businessHourRequest -> BusinessHour.ofCreateBusinessHour(businessHourRequest, storeMeta))
+                .collect(Collectors.toList()));
+
         // when
         businessHourService.updateBusinessHours(storeMeta, updateBusinessHours);
-
+        List<BusinessHour> foundStore = businessHourRepository.findByStoreMetaId(1L);
         // then
-        assertAll(
-                () -> assertThat(monday.getOpenAt()).isEqualTo(updateMonday.getOpenAt()),
-                () -> assertThat(monday.getCloseAt()).isEqualTo(updateMonday.getCloseAt()),
-                () -> assertThat(tuesday.getOpenAt()).isEqualTo(updateTuesday.getOpenAt()),
-                () -> assertThat(tuesday.getCloseAt()).isEqualTo(updateTuesday.getCloseAt()),
-                () -> assertThat(wednesday.getOpenAt()).isEqualTo(updateWednesday.getOpenAt()),
-                () -> assertThat(wednesday.getCloseAt()).isEqualTo(updateWednesday.getCloseAt()),
-                () -> assertThat(thursday.getOpenAt()).isEqualTo(updateThursday.getOpenAt()),
-                () -> assertThat(thursday.getCloseAt()).isEqualTo(updateThursday.getCloseAt()),
-                () -> assertThat(friday.getOpenAt()).isEqualTo(updateFriday.getOpenAt()),
-                () -> assertThat(friday.getCloseAt()).isEqualTo(updateFriday.getCloseAt()),
-                () -> assertThat(saturday.getOpenAt()).isEqualTo(updateSaturday.getOpenAt()),
-                () -> assertThat(saturday.getCloseAt()).isEqualTo(updateSaturday.getCloseAt()),
-                () -> assertThat(sunday.getOpenAt()).isEqualTo(updateSunday.getOpenAt()),
-                () -> assertThat(sunday.getCloseAt()).isEqualTo(updateSunday.getCloseAt())
-        );
+        for (int i = 0; i < businessHours.size(); i++) {
+            BusinessHour original = foundStore.get(i);
+            SingleBusinessHourRequest updated = updateBusinessHours.get(i);
+
+            assertAll(
+                    () -> assertThat(original.getOpenAt()).isEqualTo(updated.getOpenAt()),
+                    () -> assertThat(original.getCloseAt()).isEqualTo(updated.getCloseAt())
+            );
+        }
     }
 
     @Test
     @DisplayName("협업지점 응답을 위해 entity를 dto로 변경할 수 있다.")
     void test() {
-        // given
         // given
         BusinessHour monday = BusinessHour.builder()
                 .date(DayOfWeek.MONDAY)

--- a/src/test/java/upbrella/be/store/service/BusinessHourServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/BusinessHourServiceTest.java
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import upbrella.be.store.dto.request.SingleBusinessHourRequest;
 import upbrella.be.store.dto.response.SingleBusinessHourResponse;
 import upbrella.be.store.entity.BusinessHour;
+import upbrella.be.store.entity.StoreMeta;
 import upbrella.be.store.repository.BusinessHourRepository;
 
 import java.time.DayOfWeek;
@@ -228,10 +229,12 @@ class BusinessHourServiceTest {
         List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
         List<SingleBusinessHourRequest> updateBusinessHours = List.of(updateMonday, updateTuesday, updateWednesday, updateThursday, updateFriday, updateSaturday, updateSunday);
 
-        given(businessHourRepository.findByStoreMetaId(1L)).willReturn(businessHours);
-
+        StoreMeta storeMeta = StoreMeta.builder()
+                .id(1L)
+                .businessHours(businessHours)
+                .build();
         // when
-        businessHourService.updateBusinessHour(1L, updateBusinessHours);
+        businessHourService.updateBusinessHours(storeMeta, updateBusinessHours);
 
         // then
         assertAll(

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -557,7 +557,6 @@ public class StoreDetailServiceTest {
                 .longitude(44.44)
                 .content("내용 수정")
                 .password("비밀번호 수정")
-                .businessHours(businessHoursUpdate)
                 .build();
 
 

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -238,7 +238,6 @@ public class StoreDetailServiceTest {
                     .latitude(33.33)
                     .longitude(33.33)
                     .password("비밀번호")
-                    .businessHours(List.of())
                     .umbrellaLocation("우산 위치")
                     .businessHour("근무 시간")
                     .instagramId("인스타그램 주소")
@@ -246,7 +245,6 @@ public class StoreDetailServiceTest {
                     .address("주소")
                     .addressDetail("상세 주소")
                     .content("내용")
-                    .imageUrls(List.of(SingleImageUrlResponse.createImageUrlResponse(first), SingleImageUrlResponse.createImageUrlResponse(second)))
                     .build();
 
             // when

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -58,7 +58,7 @@ public class StoreDetailServiceTest {
                 .openAt(LocalTime.of(9, 0))
                 .closeAt(LocalTime.of(18, 0))
                 .build();
-        Set<BusinessHour> businessHours = Set.of(monday, tuesday);
+        List<BusinessHour> businessHours = List.of(monday, tuesday);
 
         StoreMeta storeMeta = StoreMeta.builder()
                 .id(3L)
@@ -170,7 +170,7 @@ public class StoreDetailServiceTest {
                 .name("소분류")
                 .build();
 
-        Set<BusinessHour> businessHours = Set.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
+        List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
 
 
         StoreMeta storeMeta = StoreMeta.builder()
@@ -313,7 +313,7 @@ public class StoreDetailServiceTest {
                 .name("소분류")
                 .build();
 
-        Set<BusinessHour> businessHours = Set.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
+        List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
 
 
         StoreMeta storeMeta = StoreMeta.builder()
@@ -439,7 +439,7 @@ public class StoreDetailServiceTest {
                 .closeAt(LocalTime.of(18, 0))
                 .build();
 
-        Set<BusinessHour> businessHours = Set.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
+        List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
 
         Classification classification = Classification.builder()
                 .id(1L)

--- a/src/test/java/upbrella/be/store/service/StoreImageServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreImageServiceTest.java
@@ -41,7 +41,7 @@ class StoreImageServiceTest {
     @Mock
     private StoreImageRepository storeImageRepository;
     @Mock
-    private StoreDetailRepository storeDetailRepository;
+    private StoreDetailService storeDetailService;
     @InjectMocks
     private StoreImageService storeImageService;
 
@@ -57,7 +57,7 @@ class StoreImageServiceTest {
         String randomId = storeImageService.makeRandomId();
         String expectedUrl = "https://null.s3.ap-northeast-2.amazonaws.com/store-image/filename.jpg" + randomId;
 
-        given(storeDetailRepository.getReferenceById(storeDetailId)).willReturn(storeDetail);
+        given(storeDetailService.findByStoreMetaID(storeDetailId)).willReturn(storeDetail);
         given(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).willReturn(PutObjectResponse.builder().build());
 
         // when
@@ -66,7 +66,6 @@ class StoreImageServiceTest {
 
         // then
         Assertions.assertThat(result).isEqualTo(expectedUrl);
-        verify(storeDetailRepository, times(1)).getReferenceById(storeDetailId);
         verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
         verify(storeImageRepository, times(1)).save(any(StoreImage.class));
     }

--- a/src/test/java/upbrella/be/store/service/StoreImageServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreImageServiceTest.java
@@ -18,7 +18,6 @@ import upbrella.be.store.dto.response.SingleImageUrlResponse;
 import upbrella.be.store.entity.StoreDetail;
 import upbrella.be.store.entity.StoreImage;
 import upbrella.be.store.exception.NonExistingStoreImageException;
-import upbrella.be.store.repository.StoreDetailRepository;
 import upbrella.be.store.repository.StoreImageRepository;
 
 import java.util.List;
@@ -57,7 +56,7 @@ class StoreImageServiceTest {
         String randomId = storeImageService.makeRandomId();
         String expectedUrl = "https://null.s3.ap-northeast-2.amazonaws.com/store-image/filename.jpg" + randomId;
 
-        given(storeDetailService.findByStoreMetaID(storeDetailId)).willReturn(storeDetail);
+        given(storeDetailService.findByStoreMetaId(storeDetailId)).willReturn(storeDetail);
         given(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class))).willReturn(PutObjectResponse.builder().build());
 
         // when

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -153,12 +153,12 @@ class StoreMetaServiceTest {
         private List<StoreMetaWithUmbrellaCount> storeMetaList = new ArrayList<>();
 
         private SingleCurrentLocationStoreResponse expected;
-        private Set<BusinessHour> businessHours;
+        private List<BusinessHour> businessHours;
 
         @BeforeEach
         void setUp() {
 
-            businessHours = Set.of(
+            businessHours = List.of(
                     BusinessHour.builder()
                             .id(1L)
                             .date(DayOfWeek.MONDAY)
@@ -459,7 +459,7 @@ class StoreMetaServiceTest {
                 .latitude(33.33)
                 .longitude(33.33)
                 .password("비밀번호")
-                .businessHours(Set.of(businessHour))
+                .businessHours(List.of(businessHour))
                 .build();
 
         StoreDetail storeDetail = StoreDetail.builder()
@@ -521,7 +521,7 @@ class StoreMetaServiceTest {
                     .latitude(33.33)
                     .longitude(33.33)
                     .password("비밀번호")
-                    .businessHours(Set.of(businessHour))
+                    .businessHours(List.of(businessHour))
                     .build();
 
             given(storeMetaRepository.findById(1L)).willReturn(Optional.of(storeMeta));


### PR DESCRIPTION
## 🟢 구현내용
- #317 

## 🧩 고민과 해결과정
협업지점 시간 수정 버그를 수정하였습니다. 
기존 : oneToMany에서 수정하려고 했는데, storeMeta의 영업시간의 개수와 update의 영업시간 개수가 다를 경우 에러가 발생합니다. 
개발 당시 모든 요일을 영업시간 등록한다고 생각하고 개발을 진행하였는데, FE 개발은 모든 요일을 영업시간에 추가하지 않아서 발생하는 에러였습니다. 

이를 해결하기 위해 Map에 요일, BusinessHour를 넣고 비교를 하며 데이터를 추가, 수정, 삭제를 진행하였습니다. 

고려했던 방안 중 
<img width="931" alt="스크린샷 2023-10-04 오후 4 51 42" src="https://user-images.githubusercontent.com/115435784/272501310-408bdfed-bc20-4a38-9933-667fff1efeb7.png">
협업지점 추가, 삭제를 누를 경우 api 통신을 하여 businessHour를 업데이트 하는 것도 생각했으나, FE에서 코드 변경이 많이 일어날 것 같아서 회의 후 지금처럼 결정하였습니다. 
