### PR TITLE
협업지점 리팩토링 

### DIFF
--- a/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
+++ b/src/main/java/upbrella/be/store/controller/StoreExceptionHandler.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.controller;
 
+import org.apache.tomcat.util.http.fileupload.impl.FileSizeLimitExceededException;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -105,6 +106,17 @@ public class StoreExceptionHandler {
                 .body(new CustomErrorResponse(
                         "not found",
                         404,
+                        ex.getMessage()));
+    }
+
+    @ExceptionHandler(FileSizeLimitExceededException.class)
+    public ResponseEntity<CustomErrorResponse> fileSize(FileSizeLimitExceededException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "bad request",
+                        400,
                         ex.getMessage()));
     }
 }

--- a/src/main/java/upbrella/be/store/dto/response/SingleClassificationResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleClassificationResponse.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.ClassificationType;
@@ -7,7 +8,6 @@ import upbrella.be.store.entity.ClassificationType;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-@AllArgsConstructor
 public class SingleClassificationResponse {
 
     private long id;
@@ -15,6 +15,15 @@ public class SingleClassificationResponse {
     private String name;
     private double latitude;
     private double longitude;
+
+    @QueryProjection
+    public SingleClassificationResponse(long id, ClassificationType type, String name, double latitude, double longitude) {
+        this.id = id;
+        this.type = type;
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
 
     public static SingleClassificationResponse ofCreateClassification(Classification classification) {
 

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -1,11 +1,9 @@
 package upbrella.be.store.dto.response;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.*;
 import upbrella.be.store.entity.StoreDetail;
 
 import java.io.Serializable;
-import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleStoreResponse.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 import upbrella.be.store.entity.StoreDetail;
 
@@ -8,7 +9,6 @@ import java.io.Serializable;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class SingleStoreResponse implements Serializable {
 
     private long id;
@@ -28,25 +28,23 @@ public class SingleStoreResponse implements Serializable {
     private String content;
     private String password;
 
-    public static SingleStoreResponse ofCreateSingleStoreResponse(StoreDetail storeDetail) {
-
-        return SingleStoreResponse.builder()
-                .id(storeDetail.getStoreMeta().getId())
-                .name(storeDetail.getStoreMeta().getName())
-                .category(storeDetail.getStoreMeta().getCategory())
-                .classification(SingleClassificationResponse.ofCreateClassification(storeDetail.getStoreMeta().getClassification()))
-                .subClassification(SingleSubClassificationResponse.ofCreateSubClassification(storeDetail.getStoreMeta().getSubClassification()))
-                .activateStatus(storeDetail.getStoreMeta().isActivated())
-                .address(storeDetail.getAddress())
-                .addressDetail(storeDetail.getAddressDetail())
-                .umbrellaLocation(storeDetail.getUmbrellaLocation())
-                .businessHour(storeDetail.getWorkingHour())
-                .contactNumber(storeDetail.getContactInfo())
-                .instagramId(storeDetail.getInstaUrl())
-                .latitude(storeDetail.getStoreMeta().getLatitude())
-                .longitude(storeDetail.getStoreMeta().getLongitude())
-                .content(storeDetail.getContent())
-                .password(storeDetail.getStoreMeta().getPassword())
-                .build();
+    @QueryProjection
+    public SingleStoreResponse(long id, String name, String category, SingleClassificationResponse classification, SingleSubClassificationResponse subClassification, boolean activateStatus, String address, String addressDetail, String umbrellaLocation, String businessHour, String contactNumber, String instagramId, double latitude, double longitude, String content, String password) {
+        this.id = id;
+        this.name = name;
+        this.category = category;
+        this.classification = classification;
+        this.subClassification = subClassification;
+        this.activateStatus = activateStatus;
+        this.address = address;
+        this.addressDetail = addressDetail;
+        this.umbrellaLocation = umbrellaLocation;
+        this.businessHour = businessHour;
+        this.contactNumber = contactNumber;
+        this.instagramId = instagramId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.content = content;
+        this.password = password;
     }
 }

--- a/src/main/java/upbrella/be/store/dto/response/SingleSubClassificationResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleSubClassificationResponse.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.dto.response;
 
+import com.querydsl.core.annotations.QueryProjection;
 import lombok.*;
 import upbrella.be.store.entity.Classification;
 import upbrella.be.store.entity.ClassificationType;
@@ -7,12 +8,18 @@ import upbrella.be.store.entity.ClassificationType;
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class SingleSubClassificationResponse {
 
     private long id;
     private ClassificationType type;
     private String name;
+
+    @QueryProjection
+    public SingleSubClassificationResponse(long id, ClassificationType type, String name) {
+        this.id = id;
+        this.type = type;
+        this.name = name;
+    }
 
     public static SingleSubClassificationResponse ofCreateSubClassification(Classification classification) {
 

--- a/src/main/java/upbrella/be/store/entity/StoreDetail.java
+++ b/src/main/java/upbrella/be/store/entity/StoreDetail.java
@@ -30,7 +30,7 @@ public class StoreDetail {
     private String addressDetail;
     private String content;
     @OneToMany(mappedBy = "storeDetail", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
-    private Set<StoreImage> storeImages;
+    private List<StoreImage> storeImages;
 
 
     public static StoreDetail createForSave(CreateStoreRequest request, StoreMeta storeMeta) {

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -67,7 +67,6 @@ public class StoreMeta {
     public void updateStoreMeta(StoreMeta storeMeta) {
 
         this.name = storeMeta.getName();
-        this.activated = storeMeta.isActivated();
         this.deleted = storeMeta.isDeleted();
         this.classification = storeMeta.getClassification();
         this.subClassification = storeMeta.getSubClassification();

--- a/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryCustom.java
+++ b/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryCustom.java
@@ -1,5 +1,6 @@
 package upbrella.be.store.repository;
 
+import upbrella.be.store.dto.response.SingleStoreResponse;
 import upbrella.be.store.entity.StoreDetail;
 
 import java.util.List;
@@ -10,4 +11,6 @@ public interface StoreDetailRepositoryCustom {
     List<StoreDetail> findAllStores();
 
     Optional<StoreDetail> findByStoreMetaIdUsingFetchJoin(long storeMetaId);
+
+    List<SingleStoreResponse> findAllStoresForAdmin();
 }

--- a/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryImpl.java
+++ b/src/main/java/upbrella/be/store/repository/StoreDetailRepositoryImpl.java
@@ -2,6 +2,10 @@ package upbrella.be.store.repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
+import upbrella.be.store.dto.response.QSingleClassificationResponse;
+import upbrella.be.store.dto.response.QSingleStoreResponse;
+import upbrella.be.store.dto.response.QSingleSubClassificationResponse;
+import upbrella.be.store.dto.response.SingleStoreResponse;
 import upbrella.be.store.entity.StoreDetail;
 
 import java.util.List;
@@ -40,5 +44,45 @@ public class StoreDetailRepositoryImpl implements StoreDetailRepositoryCustom {
                 .where(storeDetail.storeMeta.id.eq(storeMetaId))
                 .where(storeMeta.deleted.isFalse())
                 .fetchOne());
+    }
+
+    @Override
+    public List<SingleStoreResponse> findAllStoresForAdmin() {
+
+        return queryFactory
+                .select(new QSingleStoreResponse(
+                        storeDetail.storeMeta.id,
+                        storeDetail.storeMeta.name,
+                        storeDetail.storeMeta.category,
+                        new QSingleClassificationResponse(
+                                storeDetail.storeMeta.classification.id,
+                                storeDetail.storeMeta.classification.type,
+                                storeDetail.storeMeta.classification.name,
+                                storeDetail.storeMeta.classification.latitude,
+                                storeDetail.storeMeta.classification.longitude
+                        ),
+                        new QSingleSubClassificationResponse(
+                                storeDetail.storeMeta.subClassification.id,
+                                storeDetail.storeMeta.subClassification.type,
+                                storeDetail.storeMeta.subClassification.name
+                        ),
+                        storeDetail.storeMeta.activated,
+                        storeDetail.address,
+                        storeDetail.addressDetail,
+                        storeDetail.umbrellaLocation,
+                        storeDetail.workingHour,
+                        storeDetail.contactInfo,
+                        storeDetail.instaUrl,
+                        storeDetail.storeMeta.latitude,
+                        storeDetail.storeMeta.longitude,
+                        storeDetail.content,
+                        storeDetail.storeMeta.password
+                ))
+                .from(storeDetail)
+                .join(storeDetail.storeMeta, storeMeta)
+                .join(storeMeta.classification, classification)
+                .join(storeMeta.subClassification, classification)
+                .where(storeMeta.deleted.isFalse())
+                .fetch();
     }
 }

--- a/src/main/java/upbrella/be/store/service/StoreDetailService.java
+++ b/src/main/java/upbrella/be/store/service/StoreDetailService.java
@@ -25,7 +25,6 @@ public class StoreDetailService {
     private final UmbrellaService umbrellaService;
     private final StoreDetailRepository storeDetailRepository;
     private final BusinessHourService businessHourService;
-    private final StoreImageService storeImageService;
 
     @Transactional
     @CacheEvict(value = "stores", key = "'allStores'")
@@ -52,7 +51,7 @@ public class StoreDetailService {
                 .orElseThrow(() -> new NonExistingStoreDetailException("[ERROR] 존재하지 않는 가게입니다."));
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public StoreFindByIdResponse findStoreDetailByStoreId(long storeId) {
 
         StoreDetail storeDetail = findStoreDetailByStoreMetaId(storeId);
@@ -62,22 +61,14 @@ public class StoreDetailService {
         return StoreFindByIdResponse.fromStoreDetail(storeDetail, availableUmbrellaCount);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     @Cacheable(value = "stores", key = "'allStores'")
     public List<SingleStoreResponse> findAllStores() {
 
-        List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
-        return storeDetails.stream()
-                .map(this::createSingleStoreResponse)
-                .collect(Collectors.toList());
+        return storeDetailRepository.findAllStoresForAdmin();
     }
 
-    private SingleStoreResponse createSingleStoreResponse(StoreDetail storeDetail) {
-
-        return SingleStoreResponse.ofCreateSingleStoreResponse(storeDetail);
-    }
-
-    @Transactional
+    @Transactional(readOnly = true)
     public AllStoreIntroductionResponse findAllStoreIntroductions() {
 
         List<StoreDetail> storeDetails = storeDetailRepository.findAllStores();
@@ -100,6 +91,7 @@ public class StoreDetailService {
         storeDetailRepository.save(storeDetail);
     }
 
+    @Transactional(readOnly = true)
     public StoreDetail findByStoreMetaId(Long storeId) {
 
         return storeDetailRepository.findStoreDetailByStoreMetaId(storeId)

--- a/src/main/java/upbrella/be/store/service/StoreImageService.java
+++ b/src/main/java/upbrella/be/store/service/StoreImageService.java
@@ -94,6 +94,7 @@ public class StoreImageService {
         return UUID.randomUUID().toString().substring(0, 10);
     }
 
+    @Transactional(readOnly = true)
     public AllImageUrlResponse findAllImages(long storeId) {
 
         StoreDetail storeDetail = storeDetailService.findByStoreMetaId(storeId);

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -106,7 +106,7 @@ public class StoreMetaService {
 
         StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
-        Set<StoreImage> storeImages = storeDetail.getStoreImages();
+        List<StoreImage> storeImages = storeDetail.getStoreImages();
         if (storeImages == null || storeImages.isEmpty()) {
             throw new EssentialImageException("[ERROR] 가게 이미지가 존재하지 않으면 영업지점을 활성화할 수 없습니다.");
         }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -34,6 +34,7 @@ public class StoreMetaService {
     private final BusinessHourService businessHourService;
 
     public StoreMetaService(UmbrellaRepository umbrellaRepository, StoreMetaRepository storeMetaRepository, @Lazy StoreDetailService storeDetailService, ClassificationService classificationService, BusinessHourService businessHourService) {
+
         this.umbrellaRepository = umbrellaRepository;
         this.storeMetaRepository = storeMetaRepository;
         this.storeDetailService = storeDetailService;
@@ -53,6 +54,7 @@ public class StoreMetaService {
         return CurrentUmbrellaStoreResponse.fromUmbrella(foundUmbrella);
     }
 
+    @Transactional(readOnly = true)
     public AllCurrentLocationStoreResponse findAllStoresByClassification(long classificationId, LocalDateTime currentTime) {
 
         List<StoreMetaWithUmbrellaCount> storeMetaWithUmbrellaCounts = storeMetaRepository.findAllStoresByClassification(classificationId);
@@ -61,26 +63,6 @@ public class StoreMetaService {
                 storeMetaWithUmbrellaCounts.stream()
                         .map(storeMetaWithUmbrellaCount -> mapToSingleCurrentLocationStoreResponse(storeMetaWithUmbrellaCount, currentTime))
                         .collect(Collectors.toList())
-        );
-    }
-
-    private boolean isOpenStore(StoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount, LocalDateTime currentTime) {
-
-        List<BusinessHour> businessHours = storeMetaWithUmbrellaCount.getStoreMeta().getBusinessHours();
-
-        return businessHours.stream()
-                .filter(businessHour -> businessHour.getDate().equals(currentTime.getDayOfWeek()))
-                .filter(e -> storeMetaWithUmbrellaCount.getStoreMeta().isActivated())
-                .anyMatch(businessHour ->
-                        currentTime.toLocalTime().isAfter(businessHour.getOpenAt())
-                                && currentTime.toLocalTime().isBefore(businessHour.getCloseAt()));
-    }
-
-
-    private SingleCurrentLocationStoreResponse mapToSingleCurrentLocationStoreResponse(StoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount, LocalDateTime currentTime) {
-
-        return SingleCurrentLocationStoreResponse.fromStoreMeta(
-                isOpenStore(storeMetaWithUmbrellaCount, currentTime), storeMetaWithUmbrellaCount
         );
     }
 
@@ -106,34 +88,13 @@ public class StoreMetaService {
                 .orElseThrow(() -> new NonExistingStoreMetaException("[ERROR] 존재하지 않는 협업 지점 고유번호입니다."));
     }
 
-    private StoreMeta saveStoreMeta(CreateStoreRequest store) {
-
-        Classification classification = classificationService.findClassificationById(store.getClassificationId());
-        Classification subClassification = classificationService.findSubClassificationById(store.getSubClassificationId());
-
-        List<SingleBusinessHourRequest> businessHourRequests = store.getBusinessHours();
-
-        StoreMeta storeMeta = storeMetaRepository.save(StoreMeta.createStoreMetaForSave(store, classification, subClassification));
-
-        List<BusinessHour> businessHours = businessHourRequests.stream()
-                .map(businessHourRequest -> BusinessHour.ofCreateBusinessHour(businessHourRequest, storeMeta))
-                .collect(Collectors.toUnmodifiableList());
-
-        businessHourService.saveAllBusinessHour(businessHours);
-
-        return storeMeta;
-    }
-
-    private void saveStoreDetail(CreateStoreRequest store, StoreMeta storeMeta) {
-
-        storeDetailService.saveStoreDetail(StoreDetail.createForSave(store, storeMeta));
-    }
-
+    @Transactional(readOnly = true)
     public boolean existByStoreId(long storeId) {
 
         return storeMetaRepository.existsById(storeId);
     }
 
+    @Transactional(readOnly = true)
     public boolean existByClassificationId(long classificationId) {
 
         return storeMetaRepository.existsByClassificationId(classificationId);
@@ -160,5 +121,47 @@ public class StoreMetaService {
         StoreDetail storeDetail = storeDetailService.findStoreDetailByStoreMetaId(storeId);
 
         storeDetail.getStoreMeta().inactivateStoreStatus();
+    }
+
+    private boolean isOpenStore(StoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount, LocalDateTime currentTime) {
+
+        List<BusinessHour> businessHours = storeMetaWithUmbrellaCount.getStoreMeta().getBusinessHours();
+
+        return businessHours.stream()
+                .filter(businessHour -> businessHour.getDate().equals(currentTime.getDayOfWeek()))
+                .filter(e -> storeMetaWithUmbrellaCount.getStoreMeta().isActivated())
+                .anyMatch(businessHour ->
+                        currentTime.toLocalTime().isAfter(businessHour.getOpenAt())
+                                && currentTime.toLocalTime().isBefore(businessHour.getCloseAt()));
+    }
+
+    private SingleCurrentLocationStoreResponse mapToSingleCurrentLocationStoreResponse(StoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount, LocalDateTime currentTime) {
+
+        return SingleCurrentLocationStoreResponse.fromStoreMeta(
+                isOpenStore(storeMetaWithUmbrellaCount, currentTime), storeMetaWithUmbrellaCount
+        );
+    }
+
+    private void saveStoreDetail(CreateStoreRequest store, StoreMeta storeMeta) {
+
+        storeDetailService.saveStoreDetail(StoreDetail.createForSave(store, storeMeta));
+    }
+
+    private StoreMeta saveStoreMeta(CreateStoreRequest store) {
+
+        Classification classification = classificationService.findClassificationById(store.getClassificationId());
+        Classification subClassification = classificationService.findSubClassificationById(store.getSubClassificationId());
+
+        List<SingleBusinessHourRequest> businessHourRequests = store.getBusinessHours();
+
+        StoreMeta storeMeta = storeMetaRepository.save(StoreMeta.createStoreMetaForSave(store, classification, subClassification));
+
+        List<BusinessHour> businessHours = businessHourRequests.stream()
+                .map(businessHourRequest -> BusinessHour.ofCreateBusinessHour(businessHourRequest, storeMeta))
+                .collect(Collectors.toUnmodifiableList());
+
+        businessHourService.saveAllBusinessHour(businessHours);
+
+        return storeMeta;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,4 +20,7 @@ spring:
     store-type: redis
     timeout: 3600
 
-
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -19,3 +19,8 @@ spring:
   session:
     store-type: redis
     timeout: 3600
+
+  servlet:
+    multipart:
+      max-file-size: 10MB
+      max-request-size: 10MB

--- a/src/test/java/upbrella/be/store/entity/StoreDetailTest.java
+++ b/src/test/java/upbrella/be/store/entity/StoreDetailTest.java
@@ -25,7 +25,7 @@ class StoreDetailTest {
                 .imageUrl("https://null.s3.ap-northeast-2.amazonaws.com/store-image/filename.jpg")
                 .build();
 
-        Set<StoreImage> images = Set.of(second, first);
+        List<StoreImage> images = List.of(second, first);
         StoreDetail storeDetail = StoreDetail.builder()
                 .storeImages(images)
                 .build();

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -81,7 +81,7 @@ public class StoreDetailServiceTest {
                 .instaUrl("모티브 인서타")
                 .workingHour("매일 7시 ~ 12시")
                 .umbrellaLocation("문 앞")
-                .storeImages(Set.of())
+                .storeImages(List.of())
                 .build();
 
         StoreFindByIdResponse storeFindByIdResponseExpected = StoreFindByIdResponse.fromStoreDetail(storeDetail, 10L);
@@ -356,7 +356,7 @@ public class StoreDetailServiceTest {
                 .imageUrl("https://null.s3.ap-northeast-2.amazonaws.com/store-image/filename.jpg")
                 .build();
 
-        Set<StoreImage> images = Set.of(first, second);
+        List<StoreImage> images = List.of(first, second);
 
         StoreDetail storeDetail = StoreDetail.builder()
                 .id(1L)
@@ -495,7 +495,7 @@ public class StoreDetailServiceTest {
                 .address("주소")
                 .addressDetail("상세 주소")
                 .content("내용")
-                .storeImages(Set.of())
+                .storeImages(List.of())
                 .build();
 
         // 수정 후
@@ -637,7 +637,7 @@ public class StoreDetailServiceTest {
                 .instaUrl("모티브 인서타")
                 .workingHour("매일 7시 ~ 12시")
                 .umbrellaLocation("문 앞")
-                .storeImages(Set.of(StoreImage.builder().imageUrl("가게 썸네일").build()))
+                .storeImages(List.of(StoreImage.builder().imageUrl("가게 썸네일").build()))
                 .build();
 
         StoreIntroductionsResponseByClassification storeIntroductionsResponseByClassification = StoreIntroductionsResponseByClassification

--- a/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreDetailServiceTest.java
@@ -172,7 +172,6 @@ public class StoreDetailServiceTest {
 
         List<BusinessHour> businessHours = List.of(monday, tuesday, wednesday, thursday, friday, saturday, sunday);
 
-
         StoreMeta storeMeta = StoreMeta.builder()
                 .id(1L)
                 .name("협업 지점명")
@@ -199,24 +198,41 @@ public class StoreDetailServiceTest {
 
         Set<StoreImage> images = Set.of(first, second);
 
-        StoreDetail storeDetail = StoreDetail.builder()
+        SingleStoreResponse singleStoreResponse = SingleStoreResponse.builder()
                 .id(1L)
-                .storeMeta(storeMeta)
+                .name("협업 지점명")
+                .activateStatus(true)
+                .classification(SingleClassificationResponse.builder()
+                        .id(1L)
+                        .name("대분류")
+                        .type(ClassificationType.CLASSIFICATION)
+                        .latitude(33.33)
+                        .longitude(33.33)
+                        .build())
+                .subClassification(SingleSubClassificationResponse.builder()
+                        .id(2L)
+                        .type(ClassificationType.SUB_CLASSIFICATION)
+                        .name("소분류")
+                        .build())
+                .category("카테고리")
+                .latitude(33.33)
+                .longitude(33.33)
+                .password("비밀번호")
                 .umbrellaLocation("우산 위치")
-                .workingHour("근무 시간")
-                .instaUrl("인스타그램 주소")
-                .contactInfo("연락처")
+                .businessHour("근무 시간")
+                .instagramId("인스타그램 주소")
+                .contactNumber("연락처")
                 .address("주소")
                 .addressDetail("상세 주소")
                 .content("내용")
-                .storeImages(images)
                 .build();
+
 
         @Test
         @DisplayName("모든 협업 지점의 정보를 조회할 수 있다.")
         void findAllTest() {
             // given
-            given(storeDetailRepository.findAllStores()).willReturn(List.of(storeDetail));
+            given(storeDetailRepository.findAllStoresForAdmin()).willReturn(List.of(singleStoreResponse));
 
             SingleStoreResponse expected = SingleStoreResponse.builder()
                     .id(1L)

--- a/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
+++ b/src/test/java/upbrella/be/store/service/StoreMetaServiceTest.java
@@ -564,7 +564,7 @@ class StoreMetaServiceTest {
         StoreDetail storeDetail = StoreDetail.builder()
                 .id(1L)
                 .storeMeta(storeMeta)
-                .storeImages(Set.of(StoreImage.builder()
+                .storeImages(List.of(StoreImage.builder()
                         .id(1L)
                         .imageUrl("https://image.com")
                         .build()))
@@ -591,7 +591,7 @@ class StoreMetaServiceTest {
         StoreDetail storeDetail = StoreDetail.builder()
                 .id(1L)
                 .storeMeta(storeMeta)
-                .storeImages(Set.of())
+                .storeImages(List.of())
                 .build();
 
         given(storeDetailService.findStoreDetailByStoreMetaId(1L)).willReturn(storeDetail);
@@ -615,7 +615,7 @@ class StoreMetaServiceTest {
         StoreDetail storeDetail = StoreDetail.builder()
                 .id(1L)
                 .storeMeta(storeMeta)
-                .storeImages(Set.of(StoreImage.builder()
+                .storeImages(List.of(StoreImage.builder()
                         .id(1L)
                         .imageUrl("https://image.com")
                         .build()))


### PR DESCRIPTION
## 🟢 구현내용
- #327 

## 🧩 고민과 해결과정
- 협업지점 수정 시 활성화 상태가 비활성화 되는 버그를 수정하였습니다. 
- fetchJoin으로 해결했던 N+1 문제를 필요한 필드만 조회하는 것으로 해결함과 동시에 성능을 향상시켰습니다.
- 읽기 전용 메서드의 경우 transactional readOnly를 통해 성능을 향상시켰습니다. 
- 초기에 Images의 경우 두 개 이상의 OneToMany로 인해 Set으로 타입을 선언했었는데, API 분리를 통해 더이상 Set 일 필요가 없어서 List로 변경하였습니다. 이를 통해 불필요한 정렬 로직이 사라졌습니다. 
- 이미지 등록의 경우 톰캣의 기본 제한인 1MB로 인해 발생하는 에러를 예외처리하고, 10MB까지 이미지 등록이 가능하도록 변경하였습니다.