### PR TITLE
[fix] 협업지점 테이블 조인 시 버그 발생으로 인해 우산만 반환 (#331)

### DIFF
--- a/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
+++ b/src/main/java/upbrella/be/umbrella/dto/response/UmbrellaWithHistory.java
@@ -36,5 +36,17 @@ public class UmbrellaWithHistory {
         this.missed = missed;
         this.historyId = historyId;
     }
+
+    @QueryProjection
+    public UmbrellaWithHistory(long id, StoreMeta storeMeta, long uuid, boolean rentable, boolean deleted, LocalDateTime createdAt, String etc, boolean missed) {
+        this.id = id;
+        this.storeMeta = storeMeta;
+        this.uuid = uuid;
+        this.rentable = rentable;
+        this.deleted = deleted;
+        this.createdAt = createdAt;
+        this.etc = etc;
+        this.missed = missed;
+    }
 }
 

--- a/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
+++ b/src/main/java/upbrella/be/umbrella/repository/UmbrellaRepositoryImpl.java
@@ -94,6 +94,7 @@ public class UmbrellaRepositoryImpl implements UmbrellaRepositoryCustom {
                 .fetchCount();
     }
 
+    // TODO : history와 연동
     @Override
     public List<UmbrellaWithHistory> findUmbrellaAndHistoryOrderedByUmbrellaId(Pageable pageable) {
 
@@ -105,16 +106,13 @@ public class UmbrellaRepositoryImpl implements UmbrellaRepositoryCustom {
                 umbrella.deleted,
                 umbrella.createdAt,
                 umbrella.etc,
-                umbrella.missed,
-                history.id
+                umbrella.missed
         );
 
         return queryFactory.select(umbrellaWithHistory)
-                .from(history)
-                .rightJoin(history.umbrella, umbrella)
+                .from(umbrella)
                 .join(umbrella.storeMeta)
-                .where(umbrella.deleted.eq(false)
-                        .and(history.returnedAt.isNull()))
+                .where(umbrella.deleted.eq(false))
                 .orderBy(umbrella.id.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())


### PR DESCRIPTION
## 🟢 구현내용
- #331 

## 🧩 고민과 해결과정
- 기존 코드는 우산 대여 내역이 있을 경우 정상적으로 우산 전체 조회가 되지 않는 문제가 있었습니다.
- 협업지점과 연동해서 수정하기엔 배포 전 시간이 부족하여, 우산이라도 정상적으로 반환되도록 수정하였습니다. 
- 이 부분은 추후 회의를 통해 기능을 제거하거나 수정할 방법을 찾아야 할 것 같습니다.