### PR TITLE
[feat] 계좌정보 등록 / 수정 시 숫자만 입력할 수 있도록 변경  #337 

### DIFF
--- a/src/main/java/upbrella/be/user/dto/request/JoinRequest.java
+++ b/src/main/java/upbrella/be/user/dto/request/JoinRequest.java
@@ -1,6 +1,7 @@
 package upbrella.be.user.dto.request;
 
 import lombok.*;
+import upbrella.be.user.validation.OnlyNumbers;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Pattern;
@@ -22,5 +23,6 @@ public class JoinRequest {
     @Size(max = 40)
     private String bank;
     @Size(max = 40)
+    @OnlyNumbers
     private String accountNumber;
 }

--- a/src/main/java/upbrella/be/user/dto/request/UpdateBankAccountRequest.java
+++ b/src/main/java/upbrella/be/user/dto/request/UpdateBankAccountRequest.java
@@ -2,6 +2,7 @@ package upbrella.be.user.dto.request;
 
 import lombok.*;
 import org.hibernate.validator.constraints.Range;
+import upbrella.be.user.validation.OnlyNumbers;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
@@ -17,5 +18,6 @@ public class UpdateBankAccountRequest {
     private String bank;
     @Size(min = 1, max = 45)
     @NotBlank
+    @OnlyNumbers
     private String accountNumber;
 }

--- a/src/main/java/upbrella/be/user/validation/OnlyNumbers.java
+++ b/src/main/java/upbrella/be/user/validation/OnlyNumbers.java
@@ -1,0 +1,19 @@
+package upbrella.be.user.validation;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = OnlyNumbersValidator.class)
+public @interface OnlyNumbers {
+    String message() default "The field should contain only numbers";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/upbrella/be/user/validation/OnlyNumbersValidator.java
+++ b/src/main/java/upbrella/be/user/validation/OnlyNumbersValidator.java
@@ -1,0 +1,18 @@
+package upbrella.be.user.validation;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+public class OnlyNumbersValidator implements ConstraintValidator<OnlyNumbers, String> {
+
+    @Override
+    public void initialize(OnlyNumbers constraintAnnotation) {
+    }
+
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+
+        if (value == null) return true;
+        return value.matches("^\\d+$");
+    }
+}

--- a/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
+++ b/src/test/java/upbrella/be/config/FixtureBuilderFactory.java
@@ -57,9 +57,7 @@ public class FixtureBuilderFactory {
 
         StringBuilder sb = new StringBuilder();
         sb.append(Arbitraries.integers().between(100, 999).sample())
-                .append("-")
                 .append(Arbitraries.integers().between(100, 999).sample())
-                .append("-")
                 .append(Arbitraries.integers().between(100000, 999999).sample());
 
         return sb.toString();


### PR DESCRIPTION
## 🟢 구현내용
- #337 

## 🧩 고민과 해결과정
- 기존 요구사항이 명확하지 않을 때 '-' 를 어떻게 처리할 지 결정되지 않아서 banckAccount를 String 타입으로 선언하였습니다. 
- 현재 배포 전 단계에서 FE의 구현 내용을 보았을 때, '-' 없이 구현하도록 되어 있어 숫자만 입력할 수 있도록 어노테이션을 만들었습니다. 
- 추후 요구사항이 달라질 수 있다고 판단되어, 타입을 바꾸는 것이 아닌 어노테이션을 만드는 것을 택하였습니다. 