### PR TITLE
[fix] store와 classification 삭제 로직 수정

### DIFF
--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -78,6 +78,8 @@ public class StoreMeta {
 
     public void delete() {
 
+        this.classification = null;
+        this.subClassification = null;
         this.deleted = true;
     }
 

--- a/src/main/java/upbrella/be/store/repository/StoreMetaRepository.java
+++ b/src/main/java/upbrella/be/store/repository/StoreMetaRepository.java
@@ -7,7 +7,5 @@ import java.util.Optional;
 
 public interface StoreMetaRepository extends JpaRepository<StoreMeta, Long>, StoreMetaRepositoryCustom {
 
-    Optional<StoreMeta> findByIdAndDeletedIsFalse(long id);
-
-    boolean existsByClassificationId(long id);
+    Optional<StoreMeta> findByClassificationIdAndDeletedIsFalse(long id);
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -21,6 +21,7 @@ import upbrella.be.umbrella.repository.UmbrellaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -97,7 +98,9 @@ public class StoreMetaService {
     @Transactional(readOnly = true)
     public boolean existByClassificationId(long classificationId) {
 
-        return storeMetaRepository.existsByClassificationId(classificationId);
+        Optional<StoreMeta> store = storeMetaRepository.findByClassificationIdAndDeletedIsFalse(classificationId);
+
+        return store.isPresent();
     }
 
     @Transactional


### PR DESCRIPTION
## 🟢 구현내용
- #360 
- store와 classification 삭제 로직 수정

## 🧩 고민과 해결과정
- 기존 store soft delete 로직: store의 delete column을 true로 변경
- 수정된 store soft delte 로직: 기존 로직 + classification, subclassification column을 null로 변경

기존 로직의 문제점과 해결과정
> store 테이블은 classificationId, subClassificationId를 fk로 참조하고 있습니다. 
> 이로 인해 deleted가 false인 store 중에는 삭제하려고 하는 classification을 참조하고 있는 store가 없더라도 deleted true인 store가 있다면 해당 classification을 삭제하지 못하는 문제가 있었습니다.
> 이를 해결하기 위해 store를 soft delete 할 경우 classification과 subclassification에 대해서도 null 처리를 하도록 수정했습니다.