### PR TITLE
[fix] 대여 로직 순서 수정으로 자물쇠 관련 검증을 거치지 않아도 대여되는 로직 수정

### DIFF
--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -78,9 +78,10 @@ public class RentController {
         SessionUser user = (SessionUser) httpSession.getAttribute("user");
         User userToRent = userService.findUserById(user.getId());
 
+        LockerPasswordResponse lockerPasswordResponse = lockerService.findLockerPassword(rentUmbrellaByUserRequest);
+
         rentService.addRental(rentUmbrellaByUserRequest, userToRent);
 
-        LockerPasswordResponse lockerPasswordResponse = lockerService.findLockerPassword(rentUmbrellaByUserRequest);
         log.info("UBU 우산 대여 성공");
 
         return ResponseEntity


### PR DESCRIPTION
## 🟢 구현내용
우산 대여 시 자물쇠 관련 로직이 대여 가능 여부 로직보다 뒤에 있어 자물쇠 관련 로직에서 문제가 생겨도 대여가 돼버리는 문제 해결을 위해 순서 변경

