### PR TITLE
0.5.0 release-dev

### DIFF
--- a/src/docs/asciidoc/api/store/store.adoc
+++ b/src/docs/asciidoc/api/store/store.adoc
@@ -43,3 +43,27 @@ include::{snippets}/store-find-store-introduction-doc/http-request.adoc[]
 ==== HTTP Response
 include::{snippets}/store-find-store-introduction-doc/http-response.adoc[]
 include::{snippets}/store-find-store-introduction-doc/response-fields-data.adoc[]
+
+=== 보관함 전체 조회
+==== HTTP Request
+include::{snippets}/find-all-lockers/http-request.adoc[]
+
+==== HTTP Response
+include::{snippets}/find-all-lockers/http-response.adoc[]
+include::{snippets}/find-all-lockers/response-fields-data.adoc[]
+
+=== 보관함 생성
+==== HTTP Request
+include::{snippets}/create-locker/http-request.adoc[]
+include::{snippets}/create-locker/request-fields.adoc[]
+
+=== 보관함 수정
+==== HTTP Request
+include::{snippets}/update-locker/http-request.adoc[]
+include::{snippets}/update-locker/path-parameters.adoc[]
+include::{snippets}/update-locker/request-fields.adoc[]
+
+=== 보관함 삭제
+==== HTTP Request
+include::{snippets}/delete-locker/http-request.adoc[]
+include::{snippets}/delete-locker/path-parameters.adoc[]

--- a/src/main/java/upbrella/be/rent/controller/RentController.java
+++ b/src/main/java/upbrella/be/rent/controller/RentController.java
@@ -78,9 +78,10 @@ public class RentController {
         SessionUser user = (SessionUser) httpSession.getAttribute("user");
         User userToRent = userService.findUserById(user.getId());
 
+        LockerPasswordResponse lockerPasswordResponse = lockerService.findLockerPassword(rentUmbrellaByUserRequest);
+
         rentService.addRental(rentUmbrellaByUserRequest, userToRent);
 
-        LockerPasswordResponse lockerPasswordResponse = lockerService.findLockerPassword(rentUmbrellaByUserRequest);
         log.info("UBU 우산 대여 성공");
 
         return ResponseEntity

--- a/src/main/java/upbrella/be/rent/controller/RentExceptionHandler.java
+++ b/src/main/java/upbrella/be/rent/controller/RentExceptionHandler.java
@@ -129,4 +129,16 @@ public class RentExceptionHandler {
                         e.getMessage()
                 ));
     }
+
+    @ExceptionHandler(CannotBeRentedException.class)
+    public ResponseEntity<CustomErrorResponse> cannotBeRentedException(CannotBeRentedException e) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "fail",
+                        400,
+                        e.getMessage()
+                ));
+    }
 }

--- a/src/main/java/upbrella/be/rent/entity/Locker.java
+++ b/src/main/java/upbrella/be/rent/entity/Locker.java
@@ -31,4 +31,9 @@ public class Locker {
     public void updateLastAccess(LocalDateTime now) {
         this.lastAccess = now;
     }
+
+    public void updateLocker(StoreMeta storeMeta, String secretKey) {
+        this.storeMeta = storeMeta;
+        this.secretKey = secretKey;
+    }
 }

--- a/src/main/java/upbrella/be/rent/exception/CannotBeRentedException.java
+++ b/src/main/java/upbrella/be/rent/exception/CannotBeRentedException.java
@@ -1,0 +1,10 @@
+package upbrella.be.rent.exception;
+
+public class CannotBeRentedException extends RuntimeException {
+
+    public CannotBeRentedException(String message) {
+
+        super(message);
+    }
+
+}

--- a/src/main/java/upbrella/be/rent/service/LockerService.java
+++ b/src/main/java/upbrella/be/rent/service/LockerService.java
@@ -41,6 +41,9 @@ public class LockerService {
         }
 
         if (lockerOptional.isPresent()) {
+            if (salt == null || signature == null) {
+                throw new NoSignatureException("허위 반납을 위해 디지털 서명이 필요합니다. 관리자에게 문의주시기 바랍니다");
+            }
             Locker locker = lockerOptional.get();
             String lockerSecretKey = locker.getSecretKey().toUpperCase();
             salt = salt.toUpperCase();

--- a/src/main/java/upbrella/be/rent/service/RentService.java
+++ b/src/main/java/upbrella/be/rent/service/RentService.java
@@ -48,6 +48,10 @@ public class RentService {
 
         Umbrella umbrella = umbrellaService.findUmbrellaById(umbrellaId);
 
+        if (umbrella.validateCannotBeRented()) {
+            throw new CannotBeRentedException("[ERROR] 해당 우산은 대여 불가능한 우산입니다.");
+        }
+
         return RentFormResponse.of(umbrella);
     }
 

--- a/src/main/java/upbrella/be/store/controller/LockerController.java
+++ b/src/main/java/upbrella/be/store/controller/LockerController.java
@@ -1,0 +1,73 @@
+package upbrella.be.store.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import upbrella.be.rent.service.LockerService;
+import upbrella.be.store.dto.request.CreateLockerRequest;
+import upbrella.be.store.dto.request.UpdateLockerRequest;
+import upbrella.be.store.dto.response.AllLockerResponse;
+import upbrella.be.util.CustomResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class LockerController {
+
+    private final LockerService lockerService;
+
+    @GetMapping("/admin/lockers")
+    public ResponseEntity<CustomResponse<AllLockerResponse>> getLockers() {
+
+        AllLockerResponse lockers = lockerService.findAll();
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "보관함 조회 성공",
+                        lockers));
+    }
+
+    @PostMapping("/admin/lockers")
+    public ResponseEntity<CustomResponse<Void>> createLocker(@RequestBody CreateLockerRequest request) {
+
+        lockerService.createLocker(request);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "보관함 생성 성공",
+                        null));
+    }
+
+    @PatchMapping("/admin/lockers/{lockerId}")
+    public ResponseEntity<CustomResponse<Void>> updateLocker(@PathVariable Long lockerId, @RequestBody UpdateLockerRequest request) {
+
+        lockerService.updateLocker(lockerId, request);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "보관함 업데이트 성공",
+                        null));
+    }
+
+    @DeleteMapping("/admin/lockers/{lockerId}")
+    public ResponseEntity<CustomResponse<Void>> deleteLocker(@PathVariable Long lockerId) {
+
+        lockerService.deleteLocker(lockerId);
+
+        return ResponseEntity
+                .ok()
+                .body(new CustomResponse<>(
+                        "success",
+                        200,
+                        "보관함 삭제 성공",
+                        null));
+    }
+}

--- a/src/main/java/upbrella/be/store/controller/LockerExceptionHandler.java
+++ b/src/main/java/upbrella/be/store/controller/LockerExceptionHandler.java
@@ -1,0 +1,21 @@
+package upbrella.be.store.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import upbrella.be.util.CustomErrorResponse;
+
+@RestControllerAdvice
+public class LockerExceptionHandler {
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<CustomErrorResponse> nonExistingStoreDetail(IllegalArgumentException ex) {
+
+        return ResponseEntity
+                .badRequest()
+                .body(new CustomErrorResponse(
+                        "bad request",
+                        400,
+                        ex.getMessage()));
+    }
+}

--- a/src/main/java/upbrella/be/store/dto/request/CreateLockerRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/CreateLockerRequest.java
@@ -1,0 +1,16 @@
+package upbrella.be.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateLockerRequest {
+
+    private long storeId;
+    private String secretKey;
+}

--- a/src/main/java/upbrella/be/store/dto/request/UpdateLockerRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/UpdateLockerRequest.java
@@ -1,0 +1,16 @@
+package upbrella.be.store.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateLockerRequest {
+
+    private long storeId;
+    private String secretKey;
+}

--- a/src/main/java/upbrella/be/store/dto/response/AllLockerResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/AllLockerResponse.java
@@ -1,0 +1,17 @@
+package upbrella.be.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AllLockerResponse {
+
+    private List<SingleLockerResponse> lockers;
+}

--- a/src/main/java/upbrella/be/store/dto/response/SingleLockerResponse.java
+++ b/src/main/java/upbrella/be/store/dto/response/SingleLockerResponse.java
@@ -1,0 +1,27 @@
+package upbrella.be.store.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import upbrella.be.rent.entity.Locker;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SingleLockerResponse {
+
+    private long id;
+    private long storeMetaId;
+    private String secretKey;
+
+    public static SingleLockerResponse fromLocker(Locker locker) {
+
+        return SingleLockerResponse.builder()
+                .id(locker.getId())
+                .storeMetaId(locker.getStoreMeta().getId())
+                .secretKey(locker.getSecretKey())
+                .build();
+    }
+}

--- a/src/main/java/upbrella/be/store/entity/StoreMeta.java
+++ b/src/main/java/upbrella/be/store/entity/StoreMeta.java
@@ -78,6 +78,8 @@ public class StoreMeta {
 
     public void delete() {
 
+        this.classification = null;
+        this.subClassification = null;
         this.deleted = true;
     }
 

--- a/src/main/java/upbrella/be/store/repository/StoreMetaRepository.java
+++ b/src/main/java/upbrella/be/store/repository/StoreMetaRepository.java
@@ -7,7 +7,5 @@ import java.util.Optional;
 
 public interface StoreMetaRepository extends JpaRepository<StoreMeta, Long>, StoreMetaRepositoryCustom {
 
-    Optional<StoreMeta> findByIdAndDeletedIsFalse(long id);
-
-    boolean existsByClassificationId(long id);
+    Optional<StoreMeta> findByClassificationIdAndDeletedIsFalse(long id);
 }

--- a/src/main/java/upbrella/be/store/service/StoreMetaService.java
+++ b/src/main/java/upbrella/be/store/service/StoreMetaService.java
@@ -21,6 +21,7 @@ import upbrella.be.umbrella.repository.UmbrellaRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -97,7 +98,9 @@ public class StoreMetaService {
     @Transactional(readOnly = true)
     public boolean existByClassificationId(long classificationId) {
 
-        return storeMetaRepository.existsByClassificationId(classificationId);
+        Optional<StoreMeta> store = storeMetaRepository.findByClassificationIdAndDeletedIsFalse(classificationId);
+
+        return store.isPresent();
     }
 
     @Transactional

--- a/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
+++ b/src/main/java/upbrella/be/umbrella/entity/Umbrella.java
@@ -29,6 +29,7 @@ public class Umbrella {
     private boolean missed;
 
     public void delete() {
+
         this.deleted = true;
     }
 
@@ -73,6 +74,12 @@ public class Umbrella {
     }
 
     public void returnUmbrella() {
+
         this.rentable = true;
+    }
+
+    public boolean validateCannotBeRented() {
+
+        return missed || deleted || !rentable;
     }
 }

--- a/src/test/java/upbrella/be/store/controller/LockerControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/LockerControllerTest.java
@@ -1,0 +1,153 @@
+package upbrella.be.store.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.restdocs.payload.JsonFieldType;
+import upbrella.be.docs.utils.RestDocsSupport;
+import upbrella.be.rent.service.LockerService;
+import upbrella.be.store.dto.request.CreateLockerRequest;
+import upbrella.be.store.dto.request.UpdateLockerRequest;
+import upbrella.be.store.dto.response.AllLockerResponse;
+import upbrella.be.store.dto.response.SingleLockerResponse;
+
+import java.util.List;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.pathParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentRequest;
+import static upbrella.be.docs.utils.ApiDocumentUtils.getDocumentResponse;
+
+@ExtendWith(MockitoExtension.class)
+class LockerControllerTest extends RestDocsSupport {
+
+    @Mock
+    private LockerService lockerService;
+
+    @Test
+    @DisplayName("모든 보관함을 조회할 수 있다.")
+    void findAllLockerTest() throws Exception {
+        // given
+        SingleLockerResponse locker = SingleLockerResponse.builder()
+                .id(1L)
+                .storeMetaId(1L)
+                .secretKey("secretKey")
+                .build();
+
+        AllLockerResponse response = AllLockerResponse.builder()
+                .lockers(List.of(locker))
+                .build();
+
+        given(lockerService.findAll()).willReturn(response);
+
+        // when & then
+        mockMvc.perform(
+                        get("/admin/lockers")
+                ).andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("find-all-lockers",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        responseFields(
+                                beneathPath("data").withSubsectionId("data"),
+                                fieldWithPath("lockers").type(JsonFieldType.ARRAY)
+                                        .description("보관함 목록"),
+                                fieldWithPath("lockers[].id").type(JsonFieldType.NUMBER)
+                                        .description("보관함 ID"),
+                                fieldWithPath("lockers[].storeMetaId").type(JsonFieldType.NUMBER)
+                                        .description("보관함이 속한 매장 ID"),
+                                fieldWithPath("lockers[].secretKey").type(JsonFieldType.STRING)
+                                        .description("보관함 비밀키")
+                        )));
+    }
+
+    @Test
+    @DisplayName("새로운 보관함을 생성할 수 있다.")
+    void createLockerTest() throws Exception {
+        // given
+        CreateLockerRequest request = CreateLockerRequest.builder()
+                .storeId(1L)
+                .secretKey("secretKey")
+                .build();
+
+        // then
+        mockMvc.perform(post("/admin/lockers")
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType("application/json"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("create-locker",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        requestFields(
+                                fieldWithPath("storeId").type(JsonFieldType.NUMBER)
+                                        .description("보관함이 속할 매장 ID"),
+                                fieldWithPath("secretKey").type(JsonFieldType.STRING)
+                                        .description("보관함 비밀키")
+                        )));
+    }
+
+    @Test
+    @DisplayName("보관함의 정보를 수정할 수 있다.")
+    void updateLockerTest() throws Exception {
+        // given
+        UpdateLockerRequest request = UpdateLockerRequest.builder()
+                .storeId(1L)
+                .secretKey("secretKey")
+                .build();
+        Long lockerId = 1L;
+
+        // when
+
+        // then
+        mockMvc.perform(patch("/admin/lockers/{lockerId}", lockerId)
+                        .content(objectMapper.writeValueAsString(request))
+                        .contentType("application/json"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("update-locker",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("lockerId").description("보관함 ID")
+                        ),
+                        requestFields(
+                                fieldWithPath("storeId").type(JsonFieldType.NUMBER)
+                                        .description("보관함이 속할 매장 ID"),
+                                fieldWithPath("secretKey").type(JsonFieldType.STRING)
+                                        .description("보관함 비밀키")
+                        )));
+    }
+
+    @Test
+    @DisplayName("보관함을 삭제할 수 있다.")
+    void deleteLockerTest() throws Exception {
+        // given
+        Long lockerId = 1L;
+
+        // then
+        mockMvc.perform(delete("/admin/lockers/{lockerId}", lockerId))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andDo(document("delete-locker",
+                        getDocumentRequest(),
+                        getDocumentResponse(),
+                        pathParameters(
+                                parameterWithName("lockerId").description("보관함 ID")
+                        )));
+    }
+
+    @Override
+    protected Object initController() {
+        return new LockerController(lockerService);
+    }
+}


### PR DESCRIPTION
## What's Changed
* [feat] 보관함 HOTP 구현 by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/345
* [fix] locker 테스트 오류 수정 by @Gwonwoo-Nam in https://github.com/UPbrella/UPbrella_back/pull/347
* [Fix] 버그 수정 (#234) by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/348
* [Fix] 테스트 에러 수정 by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/353
* [Fix] 비밀번호 4자리 반환하도록 변경 및 해싱 방법 수정 by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/349
* [Fix] QA 반영 (#350) by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/354
* fix: 보관함 비밀번호 명세서 수정 (#356) by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/357
* [fix] 보관함 버그 수정 by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/358
* [feat] 비밀번호가 필요한 보관함에 반납 시 허위 salt와 signature가 없는 경우 예외 코드 추가(#361) by @acceptor-gyu in https://github.com/UPbrella/UPbrella_back/pull/364
* [fix] store와 classification 삭제 로직 수정 by @acceptor-gyu in https://github.com/UPbrella/UPbrella_back/pull/365
* [fix] 대여 로직 순서 수정으로 자물쇠 관련 검증을 거치지 않아도 대여되는 로직 수정 by @acceptor-gyu in https://github.com/UPbrella/UPbrella_back/pull/369
* [feat] 대여가 불가능한 상태의 우산 큐알을 찍었을 떄 에러 처리 by @acceptor-gyu in https://github.com/UPbrella/UPbrella_back/pull/370
* [Feat] 보관함 crud api 생성 #363 by @birdieHyun in https://github.com/UPbrella/UPbrella_back/pull/371


**Full Changelog**: https://github.com/UPbrella/UPbrella_back/compare/v0.4.3-dev...v0.5.0-dev