### PR TITLE
[Fix] secret key 최소 길이 추가

### DIFF
--- a/src/main/java/upbrella/be/store/controller/LockerController.java
+++ b/src/main/java/upbrella/be/store/controller/LockerController.java
@@ -9,6 +9,8 @@ import upbrella.be.store.dto.request.UpdateLockerRequest;
 import upbrella.be.store.dto.response.AllLockerResponse;
 import upbrella.be.util.CustomResponse;
 
+import javax.validation.Valid;
+
 @RestController
 @RequiredArgsConstructor
 public class LockerController {
@@ -30,7 +32,7 @@ public class LockerController {
     }
 
     @PostMapping("/admin/lockers")
-    public ResponseEntity<CustomResponse<Void>> createLocker(@RequestBody CreateLockerRequest request) {
+    public ResponseEntity<CustomResponse<Void>> createLocker(@RequestBody @Valid CreateLockerRequest request) {
 
         lockerService.createLocker(request);
 
@@ -44,7 +46,7 @@ public class LockerController {
     }
 
     @PatchMapping("/admin/lockers/{lockerId}")
-    public ResponseEntity<CustomResponse<Void>> updateLocker(@PathVariable Long lockerId, @RequestBody UpdateLockerRequest request) {
+    public ResponseEntity<CustomResponse<Void>> updateLocker(@PathVariable Long lockerId, @RequestBody @Valid UpdateLockerRequest request) {
 
         lockerService.updateLocker(lockerId, request);
 

--- a/src/main/java/upbrella/be/store/dto/request/CreateLockerRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/CreateLockerRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -12,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class CreateLockerRequest {
 
     private long storeId;
+    @Size(min = 32)
     private String secretKey;
 }

--- a/src/main/java/upbrella/be/store/dto/request/UpdateLockerRequest.java
+++ b/src/main/java/upbrella/be/store/dto/request/UpdateLockerRequest.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import javax.validation.constraints.Size;
+
 @Getter
 @Builder
 @NoArgsConstructor
@@ -12,5 +14,6 @@ import lombok.NoArgsConstructor;
 public class UpdateLockerRequest {
 
     private long storeId;
+    @Size(min = 32)
     private String secretKey;
 }

--- a/src/test/java/upbrella/be/store/controller/LockerControllerTest.java
+++ b/src/test/java/upbrella/be/store/controller/LockerControllerTest.java
@@ -76,7 +76,7 @@ class LockerControllerTest extends RestDocsSupport {
         // given
         CreateLockerRequest request = CreateLockerRequest.builder()
                 .storeId(1L)
-                .secretKey("secretKey")
+                .secretKey("12345678901234567890123456789012")
                 .build();
 
         // then
@@ -102,7 +102,7 @@ class LockerControllerTest extends RestDocsSupport {
         // given
         UpdateLockerRequest request = UpdateLockerRequest.builder()
                 .storeId(1L)
-                .secretKey("secretKey")
+                .secretKey("12345678901234567890123456789012")
                 .build();
         Long lockerId = 1L;
 


### PR DESCRIPTION
## 🟢 구현내용
- secret key 최소 길이 제한을 통해 우산 대여시 비밀번호로 인해 생기는 에러 제거


## 🧩 고민과 해결과정
