### PR TITLE
[Fix] 협업지점에서 우산이 없는 경우도 조회되도록 수정

### DIFF
--- a/src/main/java/upbrella/be/store/repository/StoreMetaRepositoryImpl.java
+++ b/src/main/java/upbrella/be/store/repository/StoreMetaRepositoryImpl.java
@@ -1,16 +1,15 @@
 package upbrella.be.store.repository;
 
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import upbrella.be.store.dto.response.QStoreMetaWithUmbrellaCount;
 import upbrella.be.store.dto.response.StoreMetaWithUmbrellaCount;
+import upbrella.be.store.entity.QStoreMeta;
+import upbrella.be.umbrella.entity.QUmbrella;
 
 import java.util.List;
 
-import static upbrella.be.store.entity.QBusinessHour.businessHour;
-import static upbrella.be.store.entity.QClassification.classification;
-import static upbrella.be.store.entity.QStoreMeta.storeMeta;
-import static upbrella.be.umbrella.entity.QUmbrella.umbrella;
 
 @RequiredArgsConstructor
 public class StoreMetaRepositoryImpl implements StoreMetaRepositoryCustom {
@@ -20,24 +19,21 @@ public class StoreMetaRepositoryImpl implements StoreMetaRepositoryCustom {
     @Override
     public List<StoreMetaWithUmbrellaCount> findAllStoresByClassification(long classificationId) {
 
-        QStoreMetaWithUmbrellaCount storeMetaWithUmbrellaCount = new QStoreMetaWithUmbrellaCount(
-                storeMeta,
-                umbrella.id.countDistinct().as("rentableUmbrellasCount")
-        );
-
+        QStoreMeta storeMeta = QStoreMeta.storeMeta;
+        QUmbrella umbrella = QUmbrella.umbrella;
 
         return queryFactory
-                .select(storeMetaWithUmbrellaCount)
-                .from(umbrella)
-                .rightJoin(umbrella.storeMeta, storeMeta)
-                .leftJoin(storeMeta.classification, classification).fetchJoin()
-                .where(storeMeta.deleted.eq(false)
-                        .and(storeMeta.classification.id.eq(classificationId))
-                        .and(umbrella.rentable.eq(true))
-                        .and(umbrella.missed.eq(false))
-                        .and(umbrella.deleted.eq(false)))
-                .distinct()
-                .groupBy(storeMeta)
+                .select(new QStoreMetaWithUmbrellaCount(
+                        storeMeta,
+                        JPAExpressions.select(umbrella.count())
+                                .from(umbrella)
+                                .where(umbrella.storeMeta.id.eq(storeMeta.id),
+                                        umbrella.rentable.isTrue(),
+                                        umbrella.missed.isFalse(),
+                                        umbrella.deleted.isFalse())))
+                .from(storeMeta)
+                .where(storeMeta.classification.id.eq(classificationId))
                 .fetch();
     }
+
 }


### PR DESCRIPTION
## 🟢 구현내용
- #399 

## 🧩 고민과 해결과정
- umbrella를 기준으로 조회하던 쿼리를 storeMeta를 기준으로 조회해서, 우산이 없더라도 조회되도록 수정
- umbrella Count를 서브쿼리를 활용해서 조회되도록 수정