### PR TITLE
Add rental history filter options

### DIFF
--- a/src/main/kotlin/upbrella/be/rent/dto/request/HistoryFilterRequest.kt
+++ b/src/main/kotlin/upbrella/be/rent/dto/request/HistoryFilterRequest.kt
@@ -1,5 +1,7 @@
 package upbrella.be.rent.dto.request
 
 data class HistoryFilterRequest(
-    val refunded: Boolean? = null
+    val refunded: Boolean? = null,
+    val storeId: Long? = null,
+    val paid: Boolean? = null
 )

--- a/src/main/kotlin/upbrella/be/rent/repository/RentRepositoryImpl.kt
+++ b/src/main/kotlin/upbrella/be/rent/repository/RentRepositoryImpl.kt
@@ -23,7 +23,11 @@ class RentRepositoryImpl(
             .join(history.umbrella, umbrella).fetchJoin()
             .join(history.rentStoreMeta, storeMeta).fetchJoin()
             .leftJoin(history.returnStoreMeta, storeMeta).fetchJoin()
-            .where(filterRefunded(filter))
+            .where(
+                filterRefunded(filter),
+                filterPaid(filter),
+                filterStore(filter)
+            )
             .orderBy(history.id.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
@@ -57,7 +61,11 @@ class RentRepositoryImpl(
             .join(history.umbrella, umbrella)
             .join(history.rentStoreMeta, storeMeta)
             .leftJoin(history.returnStoreMeta, storeMeta)
-            .where(filterRefunded(filter))
+            .where(
+                filterRefunded(filter),
+                filterPaid(filter),
+                filterStore(filter)
+            )
             .orderBy(history.id.desc())
             .offset(pageable.offset)
             .limit(pageable.pageSize.toLong())
@@ -67,7 +75,11 @@ class RentRepositoryImpl(
     override fun countAll(filter: HistoryFilterRequest, pageable: Pageable): Long {
         return queryFactory
             .selectFrom(history)
-            .where(filterRefunded(filter))
+            .where(
+                filterRefunded(filter),
+                filterPaid(filter),
+                filterStore(filter)
+            )
             .fetch()
             .size.toLong()
     }
@@ -95,5 +107,21 @@ class RentRepositoryImpl(
         }
 
         return history.refundedAt.isNull
+    }
+
+    private fun filterPaid(filter: HistoryFilterRequest): BooleanExpression? {
+        if (filter.paid == null) {
+            return null
+        }
+
+        return if (filter.paid == true) {
+            history.paidAt.isNotNull
+        } else {
+            history.paidAt.isNull
+        }
+    }
+
+    private fun filterStore(filter: HistoryFilterRequest): BooleanExpression? {
+        return filter.storeId?.let { history.rentStoreMeta.id.eq(it) }
     }
 }


### PR DESCRIPTION
## Summary
- support filtering rental histories by store and payment status
- expand `HistoryFilterRequest` with `storeId` and `paid`
- update QueryDSL repository to apply new filters

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841bd12d994832d9e0e6c8f9cf396c3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added new filtering options for rental history, allowing users to filter by store and payment status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->