### PR TITLE
Handle blank reports

### DIFF
--- a/src/main/kotlin/upbrella/be/rent/service/ConditionReportService.kt
+++ b/src/main/kotlin/upbrella/be/rent/service/ConditionReportService.kt
@@ -15,7 +15,9 @@ class ConditionReportService(
         ConditionReportPageResponse.of(findAllConditionReport())
 
     fun saveConditionReport(conditionReport: ConditionReport) {
-        conditionReportRepository.save(conditionReport)
+        conditionReport.content
+            ?.takeIf { it.isNotBlank() }
+            ?.let { conditionReportRepository.save(conditionReport) }
     }
 
     private fun findAllConditionReport(): List<ConditionReportResponse> =

--- a/src/main/kotlin/upbrella/be/rent/service/ImprovementReportService.kt
+++ b/src/main/kotlin/upbrella/be/rent/service/ImprovementReportService.kt
@@ -15,8 +15,9 @@ class ImprovementReportService(
         ImprovementReportPageResponse.of(findAllImprovementReport())
 
     fun save(improvementReport: ImprovementReport) {
-
-        improvementReportRepository.save(improvementReport)
+        improvementReport.content
+            ?.takeIf { it.isNotBlank() }
+            ?.let { improvementReportRepository.save(improvementReport) }
     }
 
     private fun findAllImprovementReport(): List<ImprovementReportResponse> =

--- a/src/test/kotlin/upbrella/be/rent/service/ConditionReportServiceTest.kt
+++ b/src/test/kotlin/upbrella/be/rent/service/ConditionReportServiceTest.kt
@@ -12,6 +12,7 @@ import org.mockito.BDDMockito.then
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.times
+import org.mockito.ArgumentMatchers.any
 import org.mockito.junit.jupiter.MockitoExtension
 import upbrella.be.rent.dto.response.ConditionReportPageResponse
 import upbrella.be.rent.dto.response.ConditionReportResponse
@@ -120,6 +121,24 @@ class ConditionReportServiceTest {
                     then(conditionReportRepository).should(times(1)).findAll()
                 }
             )
+        }
+    }
+
+    @Nested
+    @DisplayName("상태 신고 내용이 없으면 저장하지 않는다")
+    inner class SaveConditionReportTest {
+
+        @Test
+        @DisplayName("빈 내용일 경우 레포지토리에 저장하지 않는다")
+        fun doNotSaveWhenContentBlank() {
+            // given
+            val blankReport = ConditionReport(history = history, content = " ")
+
+            // when
+            conditionReportService.saveConditionReport(blankReport)
+
+            // then
+            then(conditionReportRepository).should(times(0)).save(any(ConditionReport::class.java))
         }
     }
 }

--- a/src/test/kotlin/upbrella/be/rent/service/ImprovementReportServiceTest.kt
+++ b/src/test/kotlin/upbrella/be/rent/service/ImprovementReportServiceTest.kt
@@ -1,0 +1,68 @@
+package upbrella.be.rent.service
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.BDDMockito.then
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.ArgumentMatchers.any
+import org.mockito.junit.jupiter.MockitoExtension
+import upbrella.be.rent.entity.ImprovementReport
+import upbrella.be.rent.repository.ImprovementReportRepository
+import upbrella.be.rent.entity.History
+import upbrella.be.store.entity.StoreMeta
+import upbrella.be.umbrella.entity.Umbrella
+import upbrella.be.user.entity.User
+import java.time.LocalDateTime
+
+@ExtendWith(MockitoExtension::class)
+class ImprovementReportServiceTest {
+
+    @Mock
+    private lateinit var improvementReportRepository: ImprovementReportRepository
+
+    @InjectMocks
+    private lateinit var improvementReportService: ImprovementReportService
+
+    private lateinit var history: History
+
+    @BeforeEach
+    fun setUp() {
+        val storeMeta = StoreMeta(
+            name = "store",
+            activated = false,
+            category = "cat",
+        )
+        val umbrella = Umbrella(
+            storeMeta = storeMeta,
+            uuid = 1L,
+            rentable = true,
+            deleted = false,
+            createdAt = LocalDateTime.now(),
+            etc = null,
+            missed = false,
+        )
+        val user = User(0L, "name", "010", "email", false, null, null, 1L)
+        history = History(
+            umbrella = umbrella,
+            user = user,
+            rentStoreMeta = storeMeta,
+        )
+    }
+
+    @Test
+    @DisplayName("빈 내용일 경우 레포지토리에 저장하지 않는다")
+    fun doNotSaveWhenContentBlank() {
+        // given
+        val blankReport = ImprovementReport(history = history, content = " ")
+
+        // when
+        improvementReportService.save(blankReport)
+
+        // then
+        then(improvementReportRepository).should(times(0)).save(any(ImprovementReport::class.java))
+    }
+}


### PR DESCRIPTION
## Summary
- ignore empty content when saving condition or improvement reports
- add regression tests for report services

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6841c029874c832d9ea00cf97db9280d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented saving of condition and improvement reports when the content is blank or missing.

- **Tests**
  - Added tests to verify that reports with blank content are not saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->